### PR TITLE
feat: Add Subresource Integrity (SRI) Hash Generator Lab

### DIFF
--- a/main.py
+++ b/main.py
@@ -296,6 +296,7 @@ KNOWN_COMMANDS = [
     "metrics-lab", "metrics",
     "trace-lab", "trace",
     "fuzz-lab", "fuzz",
+    "sri-lab", "sri",
     "static-lab", "static", "serve-static",
     "notify-lab", "notify",
     "contract-lab", "contract",
@@ -18553,6 +18554,17 @@ Examples:
         help="Action to perform."
     )
 
+    # --- New 'sri-lab' command ---
+    parser_sri = subparsers.add_parser(
+        "sri-lab",
+        aliases=["sri"],
+        help="Subresource Integrity (SRI) Hash Generator."
+    )
+    parser_sri.add_argument("--source", "-s", help="URL or local file path to compute SRI hash for.")
+    parser_sri.add_argument("--algo", "-a", choices=["sha256", "sha384", "sha512"], default="sha384", help="Hash algorithm (default: sha384)")
+    parser_sri.add_argument("--all", action="store_true", help="Output all hashes instead of just the selected one.")
+    parser_sri.add_argument("--tui", action="store_true", help="Launch SRI Lab TUI.")
+
     # fuzz cli
     parser_fuzz_cli = fuzz_subparsers.add_parser("cli", help="Fuzz a CLI command.")
     parser_fuzz_cli.add_argument("target", help="Command to fuzz (e.g. 'python3 app.py').")
@@ -23642,6 +23654,11 @@ async def main():
 
     if args.command in ["fuzz-lab", "fuzz"]:
         run_fuzz_lab(args)
+        return
+
+    if args.command in ["sri-lab", "sri"]:
+        from shared.sri_lab import run_sri_lab_logic
+        run_sri_lab_logic(args)
         return
 
     if args.command in ["static-lab", "static", "serve-static"]:

--- a/shared/emoji_lab.py
+++ b/shared/emoji_lab.py
@@ -10,7 +10,10 @@ import random
 from typing import List, Tuple, Dict, Optional
 from rich.console import Console
 from rich.table import Table
-from rich.emoji import EMOJI
+try:
+    from rich.emoji import EMOJI
+except ImportError:
+    from rich._emoji_codes import EMOJI
 
 console = Console()
 

--- a/shared/sri_lab.py
+++ b/shared/sri_lab.py
@@ -1,0 +1,122 @@
+"""
+Subresource Integrity (SRI) Lab
+===============================
+
+Computes SRI hashes (sha256, sha384, sha512) for web assets from local files or URLs.
+Generates the corresponding HTML `<script>` or `<link>` tags.
+"""
+
+import argparse
+import base64
+import hashlib
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+
+class SriManager:
+    """Manages computation of Subresource Integrity hashes."""
+
+    def __init__(self):
+        pass
+
+    def fetch_content(self, source: str) -> bytes:
+        """Fetches content from a URL or reads from a local file path."""
+        if source.startswith("http://") or source.startswith("https://"):
+            try:
+                # Add a generic User-Agent to avoid immediate 403 blocks from some CDNs
+                req = urllib.request.Request(
+                    source,
+                    headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'}
+                )
+                with urllib.request.urlopen(req) as response: # nosec B310
+                    return response.read()
+            except Exception as e:
+                raise ValueError(f"Failed to fetch URL: {e}")
+        else:
+            path = Path(source)
+            if not path.exists():
+                raise ValueError(f"File not found: {source}")
+            try:
+                return path.read_bytes()
+            except Exception as e:
+                raise ValueError(f"Failed to read file: {e}")
+
+    def compute_hashes(self, content: bytes) -> Dict[str, str]:
+        """Computes base64-encoded sha256, sha384, and sha512 digests."""
+        algorithms = {
+            'sha256': hashlib.sha256,
+            'sha384': hashlib.sha384,
+            'sha512': hashlib.sha512
+        }
+
+        results = {}
+        for algo_name, algo_func in algorithms.items():
+            digest = algo_func(content).digest()
+            b64_hash = base64.b64encode(digest).decode('utf-8')
+            results[algo_name] = f"{algo_name}-{b64_hash}"
+
+        return results
+
+    def generate_html_tag(self, source: str, integrity_hash: str) -> str:
+        """Generates the appropriate HTML tag based on the file extension."""
+        source_lower = source.lower()
+        if source_lower.endswith(".css"):
+            return f'<link rel="stylesheet" href="{source}" integrity="{integrity_hash}" crossorigin="anonymous">'
+        else:
+            # Default to script tag for .js or unknown types
+            return f'<script src="{source}" integrity="{integrity_hash}" crossorigin="anonymous"></script>'
+
+
+def run_sri_lab_logic(args: argparse.Namespace) -> bool:
+    """CLI handler for SRI Lab."""
+    if getattr(args, "tui", False):
+        from shared.tui import AgentTUI
+        print("Launching SRI Lab TUI...")
+        app = AgentTUI(project_dir=getattr(args, 'project_dir', None), start_tab="tab-sri")
+        import asyncio
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop and loop.is_running():
+            asyncio.ensure_future(app.run_async())
+        else:
+            app.run()
+        sys.exit(0)
+        return True
+
+    manager = SriManager()
+
+    source = getattr(args, "source", None)
+    if not source:
+        print("Error: A source (file path or URL) is required. Use --source or launch the TUI with --tui.", file=sys.stderr)
+        sys.exit(1)
+
+    algo = getattr(args, "algo", "sha384").lower()
+    if algo not in ["sha256", "sha384", "sha512"]:
+        print(f"Error: Unsupported algorithm '{algo}'. Valid options: sha256, sha384, sha512.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        content = manager.fetch_content(source)
+        hashes = manager.compute_hashes(content)
+
+        integrity_hash = hashes[algo]
+        html_tag = manager.generate_html_tag(source, integrity_hash)
+
+        print(f"Algorithm: {algo}")
+        print(f"Integrity: {integrity_hash}")
+        print(f"\nHTML Tag:\n{html_tag}")
+
+        if getattr(args, "all", False):
+            print("\nAll Hashes:")
+            for a, h in hashes.items():
+                print(f"  {a}: {h}")
+
+        return True
+
+    except Exception as e:
+        print(f"Error generating SRI: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -305,6 +305,7 @@ from shared.tui_portscan import PortScanTab
 from shared.tui_html2md import Html2MdTab
 from shared.tui_html2jsx import Html2JsxLabTab
 from shared.tui_fs import FsLabTab
+from shared.tui_sri import SriLabTab
 from shared.tui_run2compose import Run2ComposeLabTab
 from shared.tui_compose2k8s import Compose2K8sLabTab
 from shared.tui_xml2json import Xml2JsonTab
@@ -4875,6 +4876,8 @@ class AgentTUI(App):
                 yield RegexEscapeLabTab()
             with TabPane("Fuzz Lab", id="tab-fuzz"):
                 yield FuzzLabTab(self.project_dir)
+            with TabPane("SRI Lab", id="tab-sri"):
+                yield SriLabTab()
             with TabPane("OpenAPI Lab", id="tab-openapi"):
                 from shared.tui_openapi import OpenAPILabTab
                 yield OpenAPILabTab(project_dir=self.project_dir)

--- a/shared/tui_sri.py
+++ b/shared/tui_sri.py
@@ -1,0 +1,97 @@
+from textual.app import ComposeResult
+from textual.widgets import TextArea, Button, Static, Label, Select, Input
+from textual.containers import Vertical, Horizontal, Container
+
+from shared.sri_lab import SriManager
+
+
+class SriLabTab(Container):
+    """A Textual tab for computing SRI hashes and HTML tags."""
+
+    def __init__(self, project_dir=None):
+        super().__init__(id="tab-sri")
+        self.manager = SriManager()
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="p-1"):
+            yield Static("Subresource Integrity (SRI) Generator", classes="header mb-1 text-bold")
+
+            with Horizontal(classes="h-auto border-b border-primary pb-1 mb-1"):
+                with Vertical(classes="w-2-3 pr-1"):
+                    yield Label("Source (URL or local file path):", classes="mb-1")
+                    yield Input(placeholder="https://code.jquery.com/jquery-3.6.0.min.js", id="sri_source_input")
+
+                with Vertical(classes="w-1-3"):
+                    yield Label("Algorithm:", classes="mb-1")
+                    yield Select(
+                        [("SHA-384 (Recommended)", "sha384"), ("SHA-256", "sha256"), ("SHA-512", "sha512")],
+                        value="sha384",
+                        id="sri_algo_select",
+                    )
+
+            with Horizontal(classes="h-auto pb-1 mb-1"):
+                yield Button("Generate SRI", id="btn_sri_generate", variant="primary", classes="mr-1")
+                yield Button("Clear", id="btn_sri_clear", variant="error")
+
+            with Vertical(classes="h-full mt-1 border-t border-primary pt-1"):
+                yield Label("Integrity Hash:", classes="text-bold mb-1")
+                self.hash_output = Input(id="sri_hash_output", classes="mb-2")
+                # Workaround for textual versions where Input might not support read_only in __init__
+                # Usually it's read_only=True on TextArea or we just restrict.
+                yield self.hash_output
+
+                yield Label("HTML Tag:", classes="text-bold mb-1")
+                self.tag_output = TextArea(id="sri_tag_output", read_only=True, classes="h-1-3 mb-2")
+                yield self.tag_output
+
+                yield Label("All Hashes:", classes="text-bold mb-1")
+                self.all_hashes_output = TextArea(id="sri_all_hashes_output", read_only=True, classes="h-1-3")
+                yield self.all_hashes_output
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        button_id = event.button.id
+
+        if button_id == "btn_sri_clear":
+            self.query_one("#sri_source_input", Input).value = ""
+            self.hash_output.value = ""
+            self.tag_output.text = ""
+            self.all_hashes_output.text = ""
+            return
+
+        if button_id == "btn_sri_generate":
+            source = self.query_one("#sri_source_input", Input).value.strip()
+            if not source:
+                self.app.notify("Source URL or file path cannot be empty.", severity="error")
+                return
+
+            algo_select = self.query_one("#sri_algo_select", Select).value
+            if algo_select == Select.BLANK:
+                algo = "sha384"
+            else:
+                algo = str(algo_select)
+
+            try:
+                # Disable button while fetching
+                event.button.disabled = True
+
+                # Doing it synchronously blocks the TUI but it's simpler for local/small fetch
+                content = self.manager.fetch_content(source)
+                hashes = self.manager.compute_hashes(content)
+
+                integrity_hash = hashes[algo]
+                html_tag = self.manager.generate_html_tag(source, integrity_hash)
+
+                self.hash_output.value = integrity_hash
+                self.tag_output.text = html_tag
+
+                all_hashes_text = "\n".join([f"{a.upper()}: {h}" for a, h in hashes.items()])
+                self.all_hashes_output.text = all_hashes_text
+
+                self.app.notify("SRI hashes generated successfully.")
+            except Exception as e:
+                self.app.notify(f"Error: {e}", severity="error")
+                self.hash_output.value = ""
+                self.tag_output.text = ""
+                self.all_hashes_output.text = ""
+            finally:
+                event.button.disabled = False

--- a/tests/test_sri_lab.py
+++ b/tests/test_sri_lab.py
@@ -1,0 +1,117 @@
+import unittest
+import base64
+import hashlib
+from unittest.mock import patch, MagicMock
+import tempfile
+import os
+
+from shared.sri_lab import SriManager
+
+class TestSriManager(unittest.TestCase):
+    def setUp(self):
+        self.manager = SriManager()
+
+    def test_compute_hashes(self):
+        content = b"console.log('Hello');"
+
+        # Manually compute expected hashes
+        expected_sha256 = base64.b64encode(hashlib.sha256(content).digest()).decode('utf-8')
+        expected_sha384 = base64.b64encode(hashlib.sha384(content).digest()).decode('utf-8')
+        expected_sha512 = base64.b64encode(hashlib.sha512(content).digest()).decode('utf-8')
+
+        hashes = self.manager.compute_hashes(content)
+
+        self.assertEqual(hashes['sha256'], f"sha256-{expected_sha256}")
+        self.assertEqual(hashes['sha384'], f"sha384-{expected_sha384}")
+        self.assertEqual(hashes['sha512'], f"sha512-{expected_sha512}")
+
+    def test_generate_html_tag_js(self):
+        tag = self.manager.generate_html_tag("script.js", "sha384-abc")
+        self.assertEqual(tag, '<script src="script.js" integrity="sha384-abc" crossorigin="anonymous"></script>')
+
+    def test_generate_html_tag_css(self):
+        tag = self.manager.generate_html_tag("styles.css", "sha384-abc")
+        self.assertEqual(tag, '<link rel="stylesheet" href="styles.css" integrity="sha384-abc" crossorigin="anonymous">')
+
+    @patch('urllib.request.urlopen')
+    def test_fetch_content_url(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"url_content"
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+
+        content = self.manager.fetch_content("https://example.com/test.js")
+        self.assertEqual(content, b"url_content")
+        mock_urlopen.assert_called_once()
+
+    def test_fetch_content_file(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"file_content")
+            temp_path = f.name
+
+        try:
+            content = self.manager.fetch_content(temp_path)
+            self.assertEqual(content, b"file_content")
+        finally:
+            os.remove(temp_path)
+
+    def test_fetch_content_file_not_found(self):
+        with self.assertRaisesRegex(ValueError, "File not found"):
+            self.manager.fetch_content("does_not_exist.js")
+
+
+from textual.app import App
+from typing import Any
+from shared.tui_sri import SriLabTab
+from textual.widgets import Input, TextArea, Button, Select
+
+class DummyApp(App[Any]):
+    def compose(self):
+        yield SriLabTab()
+
+class TestSriLabTab(unittest.IsolatedAsyncioTestCase):
+    @patch('shared.sri_lab.SriManager.fetch_content')
+    async def test_generate_sri_ui(self, mock_fetch):
+        mock_fetch.return_value = b"console.log('UI');"
+
+        app = DummyApp()
+        async with app.run_test() as pilot:
+            # Set input
+            source_input = app.query_one("#sri_source_input", Input)
+            source_input.value = "https://example.com/script.js"
+
+            # Select algo
+            algo_select = app.query_one("#sri_algo_select", Select)
+            algo_select.value = "sha256"
+
+            # Click generate
+            await pilot.click("#btn_sri_generate")
+            await pilot.pause()
+
+            # Verify fetch was called
+            mock_fetch.assert_called_once_with("https://example.com/script.js")
+
+            # Check outputs
+            hash_out = app.query_one("#sri_hash_output", Input)
+            tag_out = app.query_one("#sri_tag_output", TextArea)
+
+            self.assertTrue(hash_out.value.startswith("sha256-"))
+            self.assertIn("integrity=\"sha256-", tag_out.text)
+            self.assertIn("script.js", tag_out.text)
+
+    async def test_clear_ui(self):
+        app = DummyApp()
+        async with app.run_test() as pilot:
+            # Set values
+            app.query_one("#sri_source_input", Input).value = "test"
+            app.query_one("#sri_hash_output", Input).value = "hash"
+            app.query_one("#sri_tag_output", TextArea).text = "tag"
+
+            # Click clear
+            await pilot.click("#btn_sri_clear")
+            await pilot.pause()
+
+            # Check cleared
+            self.assertEqual(app.query_one("#sri_source_input", Input).value, "")
+            self.assertEqual(app.query_one("#sri_hash_output", Input).value, "")
+            self.assertEqual(app.query_one("#sri_tag_output", TextArea).text, "")


### PR DESCRIPTION
This PR introduces the `sri-lab` (Subresource Integrity) feature. It calculates cryptographic hashes (`sha256`, `sha384`, `sha512`) from an asset URL or a local file and generates the standard HTML tags (`<script>` or `<link>`).

A complete Textual TUI allows users to enter the asset target and immediately visualize all hashes and copy the generated integrity tags. Appropriate CLI commands are exposed via `python main.py sri-lab`. Tests comprehensively verify network fetching logic and parsing via `pytest`.

---
*PR created automatically by Jules for task [13961034271036969964](https://jules.google.com/task/13961034271036969964) started by @process-failed-successfully*