### PR TITLE
feat: add yaml2py-lab conversion tool

### DIFF
--- a/main.py
+++ b/main.py
@@ -256,7 +256,7 @@ KNOWN_COMMANDS = [
     "bencode-lab", "bencode", "torrent",
     "msgpack-lab", "msgpack", "mpack",
     "bson-lab", "bson",
-    "crypto-lab", "crypto", "json-lab", "json", "csv-lab", "csv", "csv2sql-lab", "csv2sql", "c2s", "json2sql-lab", "json2sql", "j2s", "csv2html-lab", "csv2html", "c2h", "json2csv-lab", "j2c", "csv2json-lab", "c2j", "csv2yaml-lab", "csv2yaml", "c2y", "env2json-lab", "env2json", "json2env", "json2md-lab", "json2md", "csv2md-lab", "csv2md", "md2csv-lab", "md2csv", "m2c", "csv2toml-lab", "csv2toml", "c2t", "yaml2csv-lab", "yaml2csv", "y2c", "xml2csv-lab", "xml2csv", "x2c", "toml2csv-lab", "toml2csv", "t2c", "yaml2json-lab", "yaml2json", "y2j", "json2py-lab", "json2py", "j2py", "json2yaml-lab", "json2yaml", "j2y", "yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t", "xml2toml-lab", "xml2toml", "toml2xml", "x2t", "json2toml-lab", "json2toml", "j2t", "xml2yaml-lab", "xml2yaml", "x2y", "yaml2xml-lab", "yaml2xml", "y2x", "excel-lab", "xls", "xlsx", "excel", "template-lab", "tpl", "image-lab", "img", "exif-lab", "exif", "ocr-lab", "ocr", "media-lab", "media", "xml-lab", "xml", "lorem-lab", "lorem", "lipsum", "bip39-lab", "bip39", "magic-decode-lab", "magic-decode", "mdecode", "endian-lab", "endian",
+    "crypto-lab", "crypto", "json-lab", "json", "csv-lab", "csv", "csv2sql-lab", "csv2sql", "c2s", "json2sql-lab", "json2sql", "j2s", "csv2html-lab", "csv2html", "c2h", "json2csv-lab", "j2c", "csv2json-lab", "c2j", "csv2yaml-lab", "csv2yaml", "c2y", "env2json-lab", "env2json", "json2env", "json2md-lab", "json2md", "csv2md-lab", "csv2md", "md2csv-lab", "md2csv", "m2c", "csv2toml-lab", "csv2toml", "c2t", "yaml2csv-lab", "yaml2csv", "y2c", "xml2csv-lab", "xml2csv", "x2c", "toml2csv-lab", "toml2csv", "t2c", "yaml2json-lab", "yaml2json", "y2j", "json2py-lab", "json2py", "j2py", "json2yaml-lab", "json2yaml", "j2y", "yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t", "xml2toml-lab", "xml2toml", "toml2xml", "x2t", "json2toml-lab", "json2toml", "j2t", "xml2yaml-lab", "xml2yaml", "x2y", "yaml2xml-lab", "yaml2xml", "y2x", "yaml2py-lab", "yaml2py", "y2py", "excel-lab", "xls", "xlsx", "excel", "template-lab", "tpl", "image-lab", "img", "exif-lab", "exif", "ocr-lab", "ocr", "media-lab", "media", "xml-lab", "xml", "lorem-lab", "lorem", "lipsum", "bip39-lab", "bip39", "magic-decode-lab", "magic-decode", "mdecode", "endian-lab", "endian",
     "ical-lab", "ical", "ics",
     "markdown-lab", "md", "md-lab", "yaml-lab", "yaml", "ini-lab", "ini", "toml-lab", "toml", "net-lab", "net", "archive-lab", "arc",
     "plist-lab", "plist", "plist2json", "json2plist",
@@ -15696,6 +15696,21 @@ def parse_args(argv=None):
     parser_yaml2xml.add_argument("--root", "-r", default="root", help="XML root element name (default: 'root').")
     parser_yaml2xml.add_argument("--tui", action="store_true", help="Launch YAML to XML Lab TUI.")
 
+
+    # --- New 'yaml2py-lab' command ---
+    parser_yaml2py = subparsers.add_parser(
+        "yaml2py-lab",
+        aliases=["yaml2py", "y2py"],
+        help="Convert YAML data to Python dataclass or Pydantic format."
+    )
+    parser_yaml2py.add_argument("--file", "-f", help="Input YAML file.")
+    parser_yaml2py.add_argument("--text", "-t", help="Input YAML text.")
+    parser_yaml2py.add_argument("--output", "-o", help="Output file path.")
+    parser_yaml2py.add_argument("--framework", choices=["dataclass", "pydantic"], default="dataclass", help="Framework to use.")
+    parser_yaml2py.add_argument("--name", default="RootModel", help="Root class name.")
+    parser_yaml2py.add_argument("--tui", action="store_true", help="Launch YAML to Py Lab TUI.")
+
+
     # --- New 'csv2md-lab' command ---
     parser_csv2md = subparsers.add_parser(
         "csv2md-lab",
@@ -23950,6 +23965,16 @@ async def main():
         from shared.yaml2xml_lab import run_yaml2xml_lab_logic
         run_yaml2xml_lab_logic(args)
         return
+
+
+    if args.command in ["yaml2py-lab", "yaml2py", "y2py"]:
+        if getattr(args, "tui", False):
+            run_tui(args, "tab-yaml2py")
+            return
+        from shared.yaml2py_lab import run_yaml2py_lab_logic
+        run_yaml2py_lab_logic(args)
+        return
+
 
     if args.command in ["yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t"]:
         if getattr(args, "action", None) == "tui":

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -315,6 +315,7 @@ from shared.tui_json2xml import Json2XmlTab
 from shared.tui_xml2csv import Xml2CsvTab
 from shared.tui_xml2yaml import Xml2YamlTab
 from shared.tui_yaml2xml import Yaml2XmlTab
+from shared.tui_yaml2py import Yaml2PyLabTab
 from shared.tui_xml2toml import Xml2TomlTab
 from shared.tui_bip39 import Bip39Tab
 from shared.tui_yaml2json import Yaml2JsonLabTab
@@ -4661,6 +4662,8 @@ class AgentTUI(App):
                 yield Xml2YamlTab()
             with TabPane("YAML to XML", id="tab-yaml2xml"):
                 yield Yaml2XmlTab()
+            yield Yaml2PyLabTab()
+
 
             with TabPane("Slug Lab", id="tab-slug"):
                 yield SlugLabTab()

--- a/shared/tui_yaml2py.py
+++ b/shared/tui_yaml2py.py
@@ -1,0 +1,75 @@
+from textual.app import ComposeResult
+from textual.containers import Vertical, Horizontal
+from textual.widgets import TabPane, Label, Button, TextArea, Select, Input
+from shared.yaml2py_lab import Yaml2PyManager
+import pyperclip
+
+class Yaml2PyLabTab(TabPane):
+    """Tab pane for Yaml2Py Lab."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__("YAML to Py", id="tab-yaml2py", *args, **kwargs)
+        self.manager = Yaml2PyManager()
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="p-4"):
+            yield Label("YAML to Python Dataclass / Pydantic", classes="text-xl text-primary mb-4")
+
+            with Horizontal(classes="mb-4 h-auto"):
+                yield Label("Root Class Name:", classes="w-32")
+                yield Input(value="RootModel", id="input-yaml2py-root", classes="w-48 mr-4")
+
+                yield Label("Framework:", classes="w-24")
+                yield Select(
+                    [("Dataclass", "dataclass"), ("Pydantic", "pydantic")],
+                    value="dataclass",
+                    id="select-yaml2py-framework",
+                    classes="w-40 mr-4"
+                )
+
+                yield Button("Generate", variant="primary", id="btn-generate-yaml2py", classes="mr-4")
+                yield Button("Copy Output", variant="default", id="btn-copy-yaml2py")
+
+            with Horizontal():
+                with Vertical(classes="w-1-2 pr-2"):
+                    yield Label("Input (YAML):", classes="mb-2")
+                    yield TextArea(language="yaml", id="editor-yaml2py-in")
+                with Vertical(classes="w-1-2 pl-2"):
+                    yield Label("Output (Python):", classes="mb-2")
+                    yield TextArea(language="python", read_only=True, id="editor-yaml2py-out")
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-generate-yaml2py":
+            in_editor = self.query_one("#editor-yaml2py-in", TextArea)
+            out_editor = self.query_one("#editor-yaml2py-out", TextArea)
+
+            root_name = self.query_one("#input-yaml2py-root", Input).value or "RootModel"
+            framework = self.query_one("#select-yaml2py-framework", Select).value or "dataclass"
+
+            yaml_str = in_editor.text
+            if not yaml_str.strip():
+                if hasattr(self.app, 'notify'):
+                    self.app.notify("Input YAML cannot be empty.", severity="warning")
+                return
+
+            try:
+                result = self.manager.generate(yaml_str, framework=framework, root_name=root_name)
+                out_editor.text = result
+                if hasattr(self.app, 'notify'):
+                    self.app.notify("Python code generated successfully.")
+            except Exception as e:
+                out_editor.text = f"Error generating code:\n{e}"
+                if hasattr(self.app, 'notify'):
+                    self.app.notify(f"Error: {e}", severity="error")
+
+        elif event.button.id == "btn-copy-yaml2py":
+            out_editor = self.query_one("#editor-yaml2py-out", TextArea)
+            content = out_editor.text
+            if content:
+                try:
+                    pyperclip.copy(content)
+                    if hasattr(self.app, 'notify'):
+                        self.app.notify("Copied to clipboard!", title="Success")
+                except Exception as e:
+                    if hasattr(self.app, 'notify'):
+                        self.app.notify(f"Failed to copy: {e}", title="Error", severity="error")

--- a/shared/yaml2py_lab.py
+++ b/shared/yaml2py_lab.py
@@ -1,0 +1,175 @@
+import sys
+import yaml
+import argparse
+from typing import Dict, Any, List
+
+class Yaml2PyManager:
+    """Manager for converting YAML string to Python dataclass or Pydantic models."""
+
+    def __init__(self):
+        self.class_definitions = []
+        self.class_names = set()
+
+    def generate(self, yaml_str: str, framework: str = "dataclass", root_name: str = "RootModel") -> str:
+        self.class_definitions = []
+        self.class_names = set()
+
+        try:
+            data = yaml.safe_load(yaml_str)
+        except yaml.YAMLError as e:
+            raise ValueError(f"Invalid YAML: {e}")
+
+        if data is None:
+            return ""
+
+        if not isinstance(data, dict):
+            # If the root is a list, try to infer from the first element
+            if isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict):
+                data = data[0]
+            else:
+                raise ValueError("YAML root must be an object or a list of objects.")
+
+        self._parse_dict(data, root_name, framework)
+
+        # Note: Child classes are appended first (since we parse children recursively before the parent).
+        # This guarantees dependent types are defined before they are used.
+
+        imports = ""
+        if framework == "dataclass":
+            imports = "from dataclasses import dataclass\nfrom typing import Any, List, Optional\n\n"
+        elif framework == "pydantic":
+            imports = "from pydantic import BaseModel\nfrom typing import Any, List, Optional\n\n"
+
+        return imports + "\n\n".join(self.class_definitions)
+
+    def _parse_dict(self, data: Dict[str, Any], class_name: str, framework: str):
+        # Handle duplicate class names recursively
+        original_class_name = class_name
+        counter = 1
+        while class_name in self.class_names:
+            class_name = f"{original_class_name}{counter}"
+            counter += 1
+
+        self.class_names.add(class_name)
+
+        fields = []
+        for key, value in data.items():
+            py_type = self._infer_type(key, value, framework)
+            # Make sure key is valid python identifier
+            safe_key = self._sanitize_identifier(str(key))
+            fields.append((safe_key, py_type))
+
+        if framework == "dataclass":
+            class_def = f"@dataclass\nclass {class_name}:\n"
+        elif framework == "pydantic":
+            class_def = f"class {class_name}(BaseModel):\n"
+        else:
+            raise ValueError(f"Unknown framework: {framework}")
+
+        if not fields:
+            class_def += "    pass\n"
+        else:
+            for name, type_str in fields:
+                class_def += f"    {name}: Optional[{type_str}] = None\n"
+
+        self.class_definitions.append(class_def.rstrip())
+
+    def _infer_type(self, key: str, value: Any, framework: str) -> str:
+        if value is None:
+            return "Any"
+        elif isinstance(value, bool):
+            return "bool"
+        elif isinstance(value, int):
+            return "int"
+        elif isinstance(value, float):
+            return "float"
+        elif isinstance(value, str):
+            return "str"
+        elif isinstance(value, list):
+            if len(value) == 0:
+                return "List[Any]"
+            else:
+                # Infer type from first element
+                first_elem = value[0]
+                if isinstance(first_elem, dict):
+                    child_class_name = self._to_pascal_case(str(key)) + "Item"
+                    self._parse_dict(first_elem, child_class_name, framework)
+                    return f"List[{child_class_name}]"
+                else:
+                    item_type = self._infer_type(key, first_elem, framework)
+                    return f"List[{item_type}]"
+        elif isinstance(value, dict):
+            child_class_name = self._to_pascal_case(str(key))
+            self._parse_dict(value, child_class_name, framework)
+            return child_class_name
+        else:
+            return "Any"
+
+    def _to_pascal_case(self, s: str) -> str:
+        # replace non-alphanumeric with space
+        s = "".join([c if c.isalnum() else " " for c in s])
+        words = s.split()
+        if not words:
+            return "NestedClass"
+        return "".join(w.capitalize() for w in words)
+
+    def _sanitize_identifier(self, s: str) -> str:
+        if not s:
+            return "field"
+        # replace non-alphanumeric with underscore
+        s = "".join([c if c.isalnum() else "_" for c in s])
+        # cannot start with number
+        if s[0].isdigit():
+            s = "_" + s
+        # python keywords check
+        import keyword
+        if keyword.iskeyword(s):
+            s += "_"
+        return s
+
+def run_yaml2py_lab_logic(args) -> bool:
+    """CLI logic for the Yaml2Py lab."""
+    import sys
+    manager = Yaml2PyManager()
+
+    input_data = ""
+    if getattr(args, 'file', None):
+        try:
+            with open(args.file, 'r') as f:
+                input_data = f.read()
+        except Exception as e:
+            print(f"Error reading file: {e}", file=sys.stderr)
+            return False
+    elif getattr(args, 'text', None):
+        input_data = args.text
+    elif not sys.stdin.isatty():
+        try:
+            input_data = sys.stdin.read()
+        except Exception:
+            pass
+
+    if not input_data:
+        print("Error: No YAML input provided via --file, --text, or stdin.", file=sys.stderr)
+        return False
+
+    framework = getattr(args, 'framework', 'dataclass')
+    root_name = getattr(args, 'name', 'RootModel')
+
+    try:
+        output = manager.generate(input_data, framework=framework, root_name=root_name)
+    except ValueError as e:
+        print(f"Error generating Python code: {e}", file=sys.stderr)
+        return False
+
+    if getattr(args, 'output', None):
+        try:
+            with open(args.output, 'w') as f:
+                f.write(output)
+            print(f"Code saved to {args.output}")
+        except Exception as e:
+            print(f"Error saving to file: {e}", file=sys.stderr)
+            return False
+    else:
+        print(output)
+
+    return True

--- a/tests/test_yaml2py_lab.py
+++ b/tests/test_yaml2py_lab.py
@@ -1,0 +1,177 @@
+import pytest
+import io
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+from shared.yaml2py_lab import Yaml2PyManager, run_yaml2py_lab_logic
+
+def test_flat_dataclass():
+    manager = Yaml2PyManager()
+    yaml_str = "name: test\nage: 30\nis_active: true"
+    result = manager.generate(yaml_str, framework="dataclass", root_name="User")
+
+    assert "@dataclass" in result
+    assert "class User:" in result
+    assert "name: Optional[str] = None" in result
+    assert "age: Optional[int] = None" in result
+    assert "is_active: Optional[bool] = None" in result
+
+def test_flat_pydantic():
+    manager = Yaml2PyManager()
+    yaml_str = "id: 123\nbalance: 99.99"
+    result = manager.generate(yaml_str, framework="pydantic", root_name="Account")
+
+    assert "class Account(BaseModel):" in result
+    assert "id: Optional[int] = None" in result
+    assert "balance: Optional[float] = None" in result
+
+def test_nested_objects():
+    manager = Yaml2PyManager()
+    yaml_str = "user:\n  name: Alice\nstatus: ok"
+    result = manager.generate(yaml_str, framework="dataclass", root_name="Response")
+
+    assert "class User:" in result
+    assert "name: Optional[str] = None" in result
+    assert "class Response:" in result
+    assert "user: Optional[User] = None" in result
+    assert "status: Optional[str] = None" in result
+
+    # Check order: nested class should appear before root class
+    assert result.index("class User:") < result.index("class Response:")
+
+def test_lists():
+    manager = Yaml2PyManager()
+    yaml_str = "tags:\n  - a\n  - b\nscores:\n  - 1\n  - 2"
+    result = manager.generate(yaml_str)
+
+    assert "tags: Optional[List[str]] = None" in result
+    assert "scores: Optional[List[int]] = None" in result
+
+def test_nested_lists():
+    manager = Yaml2PyManager()
+    yaml_str = "items:\n  - id: 1\n    name: item1\n  - id: 2\n    name: item2"
+    result = manager.generate(yaml_str, framework="dataclass", root_name="Cart")
+
+    assert "class ItemsItem:" in result
+    assert "id: Optional[int] = None" in result
+    assert "name: Optional[str] = None" in result
+    assert "class Cart:" in result
+    assert "items: Optional[List[ItemsItem]] = None" in result
+
+def test_invalid_yaml():
+    manager = Yaml2PyManager()
+    with pytest.raises(ValueError):
+        manager.generate("invalid: yaml: :")
+
+def test_list_root():
+    manager = Yaml2PyManager()
+    yaml_str = "- id: 1\n- id: 2"
+    result = manager.generate(yaml_str, root_name="Item")
+
+    assert "class Item:" in result
+    assert "id: Optional[int] = None" in result
+
+def test_sanitize_identifier():
+    manager = Yaml2PyManager()
+    yaml_str = "1st_item: value\nclass: keyword\na-b: 1"
+    result = manager.generate(yaml_str)
+
+    assert "_1st_item: Optional[str] = None" in result
+    assert "class_: Optional[str] = None" in result
+    assert "a_b: Optional[int] = None" in result
+
+@patch('sys.stdout', new_callable=io.StringIO)
+def test_cli_logic_text(mock_stdout):
+    args = argparse.Namespace(
+        text="name: Charlie\nage: 40",
+        file=None,
+        output=None,
+        framework="dataclass",
+        name="TestClass",
+        tui=False
+    )
+    result = run_yaml2py_lab_logic(args)
+    assert result is True
+
+    output = mock_stdout.getvalue()
+    assert "class TestClass:" in output
+    assert "name: Optional[str] = None" in output
+
+def test_cli_logic_file(tmp_path):
+    yaml_file = tmp_path / "input.yaml"
+    yaml_file.write_text("name: David\n", encoding="utf-8")
+
+    py_file = tmp_path / "output.py"
+
+    args = argparse.Namespace(
+        text=None,
+        file=str(yaml_file),
+        output=str(py_file),
+        framework="pydantic",
+        name="Person",
+        tui=False
+    )
+
+    with patch('sys.stdout', new_callable=io.StringIO):
+        result = run_yaml2py_lab_logic(args)
+        assert result is True
+
+    assert py_file.exists()
+    assert "class Person(BaseModel):" in py_file.read_text()
+    assert "name: Optional[str] = None" in py_file.read_text()
+
+@patch('sys.stderr', new_callable=io.StringIO)
+def test_cli_logic_missing_input(mock_stderr):
+    args = argparse.Namespace(
+        text=None,
+        file=None,
+        output=None,
+        framework="dataclass",
+        name="RootModel",
+        tui=False
+    )
+    with patch('sys.stdin.isatty', return_value=True):
+        result = run_yaml2py_lab_logic(args)
+        assert result is False
+
+    assert "No YAML input provided" in mock_stderr.getvalue()
+
+@pytest.mark.asyncio
+async def test_tui_yaml2py():
+    """Test the Textual TUI interface."""
+    pytest.importorskip("textual")
+    from textual.app import App, ComposeResult
+    from shared.tui_yaml2py import Yaml2PyLabTab
+    from textual.widgets import TextArea, Select, Input
+    from textual.widgets import TabbedContent
+
+    class MockApp(App):
+        def compose(self) -> ComposeResult:
+            with TabbedContent():
+                yield Yaml2PyLabTab()
+
+    app = MockApp()
+    async with app.run_test(size=(80, 40)) as pilot:
+        await pilot.pause(0.1)
+
+        input_ta = app.query_one("#editor-yaml2py-in", TextArea)
+        output_ta = app.query_one("#editor-yaml2py-out", TextArea)
+        name_input = app.query_one("#input-yaml2py-root", Input)
+        fw_select = app.query_one("#select-yaml2py-framework", Select)
+
+        # Test valid conversion
+        yaml_data = "user:\n  id: 123\n  role: admin"
+        input_ta.load_text(yaml_data)
+
+        # Test change input
+        name_input.value = "MyApp"
+
+        from textual.widgets import Button
+        btn = app.query_one("#btn-generate-yaml2py", Button)
+        await app.query_one("Yaml2PyLabTab").on_button_pressed(Button.Pressed(btn))
+        await pilot.pause(0.1)
+
+        assert "class User:" in output_ta.text
+        assert "class MyApp:" in output_ta.text
+        assert "user: Optional[User] = None" in output_ta.text


### PR DESCRIPTION
This commit introduces the `yaml2py-lab` command line tool and TUI integration. It brings feature parity with `json2py-lab` by allowing users to seamlessly translate YAML strings and files into Python dataclasses or Pydantic models. Tests for Manager, TUI, and CLI are included.

---
*PR created automatically by Jules for task [7302707917543275644](https://jules.google.com/task/7302707917543275644) started by @process-failed-successfully*