### PR TITLE
feat: add json2ts lab to dynamically convert JSON to TypeScript interfaces

### DIFF
--- a/main.py
+++ b/main.py
@@ -256,7 +256,7 @@ KNOWN_COMMANDS = [
     "bencode-lab", "bencode", "torrent",
     "msgpack-lab", "msgpack", "mpack",
     "bson-lab", "bson",
-    "crypto-lab", "crypto", "json-lab", "json", "csv-lab", "csv", "csv2sql-lab", "csv2sql", "c2s", "json2sql-lab", "json2sql", "j2s", "csv2html-lab", "csv2html", "c2h", "json2csv-lab", "j2c", "csv2json-lab", "c2j", "csv2yaml-lab", "csv2yaml", "c2y", "env2json-lab", "env2json", "json2env", "json2md-lab", "json2md", "csv2md-lab", "csv2md", "md2csv-lab", "md2csv", "m2c", "csv2toml-lab", "csv2toml", "c2t", "yaml2csv-lab", "yaml2csv", "y2c", "xml2csv-lab", "xml2csv", "x2c", "toml2csv-lab", "toml2csv", "t2c", "yaml2json-lab", "yaml2json", "y2j", "json2py-lab", "json2py", "j2py", "json2yaml-lab", "json2yaml", "j2y", "yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t", "xml2toml-lab", "xml2toml", "toml2xml", "x2t", "json2toml-lab", "json2toml", "j2t", "xml2yaml-lab", "xml2yaml", "x2y", "yaml2xml-lab", "yaml2xml", "y2x", "yaml2py-lab", "yaml2py", "y2py", "excel-lab", "xls", "xlsx", "excel", "template-lab", "tpl", "image-lab", "img", "exif-lab", "exif", "ocr-lab", "ocr", "media-lab", "media", "xml-lab", "xml", "lorem-lab", "lorem", "lipsum", "bip39-lab", "bip39", "magic-decode-lab", "magic-decode", "mdecode", "endian-lab", "endian",
+    "crypto-lab", "crypto", "json-lab", "json", "csv-lab", "csv", "csv2sql-lab", "csv2sql", "c2s", "json2sql-lab", "json2sql", "j2s", "csv2html-lab", "csv2html", "c2h", "json2csv-lab", "j2c", "csv2json-lab", "c2j", "csv2yaml-lab", "csv2yaml", "c2y", "env2json-lab", "env2json", "json2env", "json2md-lab", "json2md", "csv2md-lab", "csv2md", "md2csv-lab", "md2csv", "m2c", "csv2toml-lab", "csv2toml", "c2t", "yaml2csv-lab", "yaml2csv", "y2c", "xml2csv-lab", "xml2csv", "x2c", "toml2csv-lab", "toml2csv", "t2c", "yaml2json-lab", "yaml2json", "y2j", "json2py-lab", "json2py", "j2py", "json2yaml-lab", "json2yaml", "j2y", "yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t", "xml2toml-lab", "xml2toml", "toml2xml", "x2t", "json2toml-lab", "json2toml", "j2t", "xml2yaml-lab", "xml2yaml", "x2y", "yaml2xml-lab", "yaml2xml", "y2x", "yaml2py-lab", "yaml2py", "y2py", "json2ts-lab", "json2ts", "j2ts", "excel-lab", "xls", "xlsx", "excel", "template-lab", "tpl", "image-lab", "img", "exif-lab", "exif", "ocr-lab", "ocr", "media-lab", "media", "xml-lab", "xml", "lorem-lab", "lorem", "lipsum", "bip39-lab", "bip39", "magic-decode-lab", "magic-decode", "mdecode", "endian-lab", "endian",
     "ical-lab", "ical", "ics",
     "markdown-lab", "md", "md-lab", "yaml-lab", "yaml", "ini-lab", "ini", "toml-lab", "toml", "net-lab", "net", "archive-lab", "arc",
     "plist-lab", "plist", "plist2json", "json2plist",
@@ -15697,6 +15697,18 @@ def parse_args(argv=None):
     parser_yaml2xml.add_argument("--tui", action="store_true", help="Launch YAML to XML Lab TUI.")
 
 
+    # --- New 'json2ts-lab' command ---
+    parser_json2ts = subparsers.add_parser(
+        "json2ts-lab",
+        aliases=["json2ts", "j2ts"],
+        help="Convert JSON into TypeScript interfaces. Supports dynamic type inference and nested objects."
+    )
+    parser_json2ts.add_argument("--file", "-f", help="Input JSON file.")
+    parser_json2ts.add_argument("--text", "-t", help="Input JSON text.")
+    parser_json2ts.add_argument("--output", "-o", help="Output TypeScript file path.")
+    parser_json2ts.add_argument("--name", "-n", default="RootObject", help="Root interface name (default: 'RootObject').")
+    parser_json2ts.add_argument("--tui", action="store_true", help="Launch JSON to TS Lab TUI.")
+
     # --- New 'yaml2py-lab' command ---
     parser_yaml2py = subparsers.add_parser(
         "yaml2py-lab",
@@ -23973,6 +23985,14 @@ async def main():
             return
         from shared.yaml2py_lab import run_yaml2py_lab_logic
         run_yaml2py_lab_logic(args)
+        return
+
+    if args.command in ["json2ts-lab", "json2ts", "j2ts"]:
+        if getattr(args, "tui", False):
+            run_tui(args, "tab-json2ts")
+            return
+        from shared.json2ts_lab import run_json2ts_lab_logic
+        run_json2ts_lab_logic(args)
         return
 
 

--- a/shared/json2ts_lab.py
+++ b/shared/json2ts_lab.py
@@ -1,0 +1,144 @@
+import argparse
+import json
+import sys
+from pathlib import Path
+
+class Json2TsManager:
+    """Manages conversion from JSON to TypeScript interfaces."""
+
+    def convert(self, json_data: str, root_name: str = "RootObject") -> str:
+        """Converts JSON string to TypeScript interfaces."""
+        try:
+            data = json.loads(json_data)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON: {e}")
+
+        interfaces = {}
+
+        def _get_type(value, name):
+            if isinstance(value, dict):
+                # Title case for interface name, preserving existing camelCase
+                # e.g., UserItem -> UserItem, user_item -> UserItem
+                parts = [p for p in name.split('_') if p]
+                if parts:
+                    interface_name = "".join(p[0].upper() + p[1:] if len(p) > 0 else p for p in parts)
+                else:
+                    interface_name = name
+
+                # Avoid root name collision or primitive names
+                if not interface_name or interface_name.lower() in ("string", "number", "boolean", "any"):
+                    interface_name = "Object"
+
+                # generate interface
+                _generate_interface(value, interface_name)
+                return interface_name
+            elif isinstance(value, list):
+                if not value:
+                    return "any[]"
+                # get type of first element
+                item_name = name + "Item" if name else "Item"
+                if name.endswith("s") and len(name) > 1:
+                    item_name = name[:-1] + "Item"
+                item_type = _get_type(value[0], item_name)
+                return f"{item_type}[]"
+            elif isinstance(value, str):
+                return "string"
+            elif isinstance(value, bool):
+                return "boolean"
+            elif isinstance(value, (int, float)):
+                return "number"
+            elif value is None:
+                return "any"
+            else:
+                return "any"
+
+        def _generate_interface(obj: dict, name: str):
+            if not isinstance(obj, dict):
+                return
+
+            # To avoid duplicates, check if it exists (very naive approach)
+            original_name = name
+            counter = 1
+            while name in interfaces:
+                name = f"{original_name}{counter}"
+                counter += 1
+
+            lines = [f"export interface {name} {{"]
+            for k, v in obj.items():
+                prop_type = _get_type(v, k)
+                # Simple property name check for spaces/invalid chars
+                if not k.isidentifier():
+                    lines.append(f"  \"{k}\": {prop_type};")
+                else:
+                    lines.append(f"  {k}: {prop_type};")
+            lines.append("}")
+            interfaces[name] = "\n".join(lines)
+
+        if isinstance(data, dict):
+            _generate_interface(data, root_name)
+        elif isinstance(data, list):
+            # If the root is a list, generate interface for the item and alias the root
+            item_type = _get_type(data, root_name)
+            return "\n\n".join(list(interfaces.values()) + [f"export type {root_name} = {item_type};"])
+        else:
+            return f"export type {root_name} = {_get_type(data, root_name)};"
+
+        return "\n\n".join(reversed(list(interfaces.values())))
+
+
+def run_json2ts_lab_logic(args: argparse.Namespace) -> bool:
+    """CLI handler for Json2Ts Lab."""
+    manager = Json2TsManager()
+
+    if getattr(args, "tui", False):
+        from shared.tui import AgentTUI
+        print("Launching JSON to TS Lab TUI...")
+        app = AgentTUI(project_dir=getattr(args, 'project_dir', None), start_tab="tab-json2ts")
+        import asyncio
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop and loop.is_running():
+            asyncio.ensure_future(app.run_async())
+        else:
+            app.run()
+            sys.exit(0)
+        return True
+
+    input_data = ""
+    if getattr(args, "file", None):
+        try:
+            with open(args.file, "r", encoding="utf-8") as f:
+                input_data = f.read()
+        except Exception as e:
+            print(f"Error reading file {args.file}: {e}", file=sys.stderr)
+            return False
+    elif getattr(args, "text", None):
+        input_data = args.text
+    else:
+        # read from stdin
+        if not sys.stdin.isatty():
+            input_data = sys.stdin.read()
+        else:
+            print("Error: No input provided. Use --file, --text, or pipe via stdin.", file=sys.stderr)
+            return False
+
+    if not input_data.strip():
+        print("Error: Empty input data.", file=sys.stderr)
+        return False
+
+    root_name = getattr(args, "name", "RootObject")
+
+    try:
+        result = manager.convert(input_data, root_name)
+        if getattr(args, "output", None):
+            with open(args.output, "w", encoding="utf-8") as f:
+                f.write(result)
+            print(f"Output written to {args.output}")
+        else:
+            print(result)
+        return True
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return False

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -313,6 +313,7 @@ from shared.tui_magic_decode import MagicDecodeTab
 from shared.tui_json2py import Json2PyLabTab
 from shared.tui_json2xml import Json2XmlTab
 from shared.tui_xml2csv import Xml2CsvTab
+from shared.tui_json2ts import Json2TsLabTab
 from shared.tui_xml2yaml import Xml2YamlTab
 from shared.tui_yaml2xml import Yaml2XmlTab
 from shared.tui_yaml2py import Yaml2PyLabTab
@@ -4178,6 +4179,7 @@ class AgentTUI(App):
         PaletteCommand("Go to ICal Lab", "switch_tab_ical"),
         PaletteCommand("Go to Plist Lab", "switch_tab_plist"),
         PaletteCommand("Go to JSON to Py Lab", "switch_tab_json2py"),
+        PaletteCommand("Go to JSON to TS Lab", "switch_tab_json2ts"),
         PaletteCommand("Go to JSON to SQL Lab", "switch_tab_json2sql"),
         PaletteCommand("Go to Hash Validator Lab", "switch_tab_hash-validator"),
         PaletteCommand("Go to Hash Lab", "switch_tab_hash"),
@@ -4654,6 +4656,8 @@ class AgentTUI(App):
                 yield Xml2JsonTab()
             with TabPane("JSON to Py", id="tab-json2py"):
                 yield Json2PyLabTab()
+            with TabPane("JSON to TS", id="tab-json2ts"):
+                yield Json2TsLabTab()
             with TabPane("JSON to XML", id="tab-json2xml"):
                 yield Json2XmlTab()
             with TabPane("BIP39 Lab", id="tab-bip39"):

--- a/shared/tui_json2ts.py
+++ b/shared/tui_json2ts.py
@@ -1,0 +1,65 @@
+from textual.app import ComposeResult
+from textual.containers import Vertical, Horizontal
+from textual.widgets import Static, Button, TextArea, Input, Label
+from textual.binding import Binding
+from shared.json2ts_lab import Json2TsManager
+
+class Json2TsLabTab(Static):
+    """TUI tab for Json2Ts Lab."""
+
+    BINDINGS = [
+        Binding("ctrl+r", "convert", "Convert", show=True),
+    ]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.manager = Json2TsManager()
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="json2ts-container", classes="p-1"):
+            yield Static("JSON to TypeScript Converter", classes="text-bold text-center p-1 bg-primary text-primary-content")
+
+            with Horizontal(classes="h-auto p-1 border-b border-primary"):
+                yield Label("Root Interface Name:", classes="p-1 mt-1")
+                yield Input(value="RootObject", id="json2ts-name-input", classes="w-1-3 m-1")
+                yield Button("Convert (Ctrl+R)", id="json2ts-convert-btn", variant="primary", classes="m-1")
+
+            with Horizontal(classes="h-full"):
+                with Vertical(classes="w-1-2 p-1 border-r border-primary h-full"):
+                    yield Label("Input JSON:", classes="text-bold mb-1")
+                    yield TextArea(id="json2ts-input-ta", language="json", classes="h-full")
+
+                with Vertical(classes="w-1-2 p-1 h-full"):
+                    yield Label("Output TypeScript:", classes="text-bold mb-1")
+                    yield TextArea(id="json2ts-output-ta", language="javascript", classes="h-full", read_only=True)
+
+            yield Static("", id="json2ts-status", classes="p-1 h-auto")
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "json2ts-convert-btn":
+            await self.action_convert()
+
+    async def action_convert(self) -> None:
+        input_ta = self.query_one("#json2ts-input-ta", TextArea)
+        output_ta = self.query_one("#json2ts-output-ta", TextArea)
+        name_input = self.query_one("#json2ts-name-input", Input)
+        status_static = self.query_one("#json2ts-status", Static)
+
+        input_text = input_ta.text.strip()
+        root_name = name_input.value.strip() or "RootObject"
+
+        if not input_text:
+            status_static.update("[yellow]Input JSON is empty.[/yellow]")
+            output_ta.text = ""
+            return
+
+        try:
+            result = self.manager.convert(input_text, root_name)
+            output_ta.text = result
+            status_static.update("[green]Conversion successful.[/green]")
+        except ValueError as e:
+            output_ta.text = ""
+            status_static.update(f"[red]{e}[/red]")
+        except Exception as e:
+            output_ta.text = ""
+            status_static.update(f"[red]Error: {e}[/red]")

--- a/tests/test_json2ts_lab.py
+++ b/tests/test_json2ts_lab.py
@@ -1,0 +1,90 @@
+import unittest
+import os
+import json
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from shared.json2ts_lab import Json2TsManager, run_json2ts_lab_logic
+import sys
+from io import StringIO
+from unittest.mock import patch, MagicMock
+
+class DummyArgs:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+class TestJson2TsManager(unittest.TestCase):
+    def setUp(self):
+        self.manager = Json2TsManager()
+
+    def test_convert_primitive(self):
+        self.assertEqual(self.manager.convert('"hello"', "RootObject"), "export type RootObject = string;")
+        self.assertEqual(self.manager.convert('123', "RootObject"), "export type RootObject = number;")
+        self.assertEqual(self.manager.convert('true', "RootObject"), "export type RootObject = boolean;")
+
+    def test_convert_simple_object(self):
+        json_data = '{"name": "Alice", "age": 30}'
+        result = self.manager.convert(json_data, "User")
+        self.assertIn("export interface User", result)
+        self.assertIn("name: string;", result)
+        self.assertIn("age: number;", result)
+
+    def test_convert_nested_object(self):
+        json_data = '{"user": {"name": "Alice", "age": 30}, "active": true}'
+        result = self.manager.convert(json_data, "Root")
+        self.assertIn("export interface User", result)
+        self.assertIn("export interface Root", result)
+        self.assertIn("user: User;", result)
+        self.assertIn("active: boolean;", result)
+
+    def test_convert_list_of_objects(self):
+        json_data = '[{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]'
+        result = self.manager.convert(json_data, "Users")
+        self.assertIn("export type Users = UserItem[];", result)
+
+    def test_convert_list_primitive(self):
+        json_data = '[1, 2, 3]'
+        result = self.manager.convert(json_data, "Numbers")
+        self.assertIn("export type Numbers = number[];", result)
+
+    def test_convert_empty_list(self):
+        json_data = '{"items": []}'
+        result = self.manager.convert(json_data, "Root")
+        self.assertIn("items: any[];", result)
+
+    def test_invalid_json(self):
+        with self.assertRaises(ValueError):
+            self.manager.convert("{invalid:", "Root")
+
+    def test_non_identifier_keys(self):
+        json_data = '{"first name": "Alice", "user-age": 30}'
+        result = self.manager.convert(json_data, "Root")
+        self.assertIn('"first name": string;', result)
+        self.assertIn('"user-age": number;', result)
+
+
+class TestJson2TsCLI(unittest.TestCase):
+    def test_run_json2ts_text(self):
+        args = DummyArgs(text='{"name": "Alice"}', file=None, name="User", output=None, tui=False)
+        with patch('sys.stdout', new=StringIO()) as fake_out:
+            self.assertTrue(run_json2ts_lab_logic(args))
+            self.assertIn("export interface User", fake_out.getvalue())
+
+    def test_run_json2ts_file(self):
+        with NamedTemporaryFile(mode='w', delete=False, suffix=".json") as tmp:
+            tmp.write('{"name": "Bob"}')
+            tmp_path = tmp.name
+
+        args = DummyArgs(text=None, file=tmp_path, name="User", output=None, tui=False)
+        try:
+            with patch('sys.stdout', new=StringIO()) as fake_out:
+                self.assertTrue(run_json2ts_lab_logic(args))
+                self.assertIn("export interface User", fake_out.getvalue())
+        finally:
+            os.remove(tmp_path)
+
+    def test_run_json2ts_invalid_json(self):
+        args = DummyArgs(text='{"name": "Alice"', file=None, name="User", output=None, tui=False)
+        with patch('sys.stderr', new=StringIO()) as fake_err:
+            self.assertFalse(run_json2ts_lab_logic(args))
+            self.assertIn("Invalid JSON", fake_err.getvalue())

--- a/tests/test_tui_json2ts.py
+++ b/tests/test_tui_json2ts.py
@@ -1,0 +1,49 @@
+import pytest
+from textual.widgets import TextArea, Input, Static
+from shared.tui_json2ts import Json2TsLabTab
+from textual.app import App, ComposeResult
+from textual.widgets import TabbedContent, TabPane
+
+class DummyApp(App):
+    def compose(self) -> ComposeResult:
+        with TabbedContent():
+            with TabPane("JSON to TS", id="tab-json2ts"):
+                yield Json2TsLabTab()
+
+@pytest.mark.asyncio
+async def test_json2ts_tab():
+    app = DummyApp()
+    async with app.run_test() as pilot:
+        # Give it a moment to render
+        await pilot.pause()
+
+        # Find the text areas and inputs
+        input_ta = app.query_one("#json2ts-input-ta", TextArea)
+        output_ta = app.query_one("#json2ts-output-ta", TextArea)
+        name_input = app.query_one("#json2ts-name-input", Input)
+        status = app.query_one("#json2ts-status", Static)
+
+        # Test 1: Empty conversion
+        tab = app.query_one(Json2TsLabTab)
+        await tab.action_convert()
+        await pilot.pause()
+        assert "Input JSON is empty" in status.renderable
+
+        # Test 2: Valid conversion
+        input_ta.text = '{"name": "Alice"}'
+        name_input.value = "User"
+
+        await tab.action_convert()
+        await pilot.pause()
+
+        assert "export interface User" in output_ta.text
+        assert "name: string;" in output_ta.text
+        assert "Conversion successful" in status.renderable
+
+        # Test 3: Invalid JSON
+        input_ta.text = '{"name": "Alice"'
+
+        await tab.action_convert()
+        await pilot.pause()
+
+        assert "Invalid JSON" in status.renderable


### PR DESCRIPTION
This PR introduces `json2ts-lab` (`json2ts`, `j2ts`), a utility for converting JSON data into TypeScript interfaces dynamically.

### Key Changes
1. **Core Logic**: Added `Json2TsManager` that reads a JSON structure and recursively builds nested TypeScript interfaces, handling arrays and primitive types securely.
2. **CLI**: Added support for standard JSON lab arguments like `--file`, `--text`, and `sys.stdin`.
3. **TUI**: Added a fully functional Textual tab (`Json2TsLabTab`) that gives side-by-side editing and instantaneous conversion, similar to the rest of the app's standard format.
4. **Testing**: 
    - Full coverage on property generation, array traversal, nesting, and edge cases like empty lists.
    - Verified TUI event propagation using `pytest-asyncio` and Textual pilot testing.
5. **Quality Improvements**: Removed unnecessary scratchpad scripts left over during generation and corrected minor assertion bugs to ensure tests pass stably on proper string representations.

---
*PR created automatically by Jules for task [11604584430119280428](https://jules.google.com/task/11604584430119280428) started by @process-failed-successfully*