### PR TITLE
Add filetype-lab for detecting file types using magic bytes

### DIFF
--- a/main.py
+++ b/main.py
@@ -253,6 +253,7 @@ KNOWN_COMMANDS = [
     "codec-lab", "codec", "currency-lab", "currency", "cur",
     "http-status-lab", "http-status", "status-code",
     "math-lab", "math", "calc-lab", "calc", "semver-lab", "semver", "sys-lab", "sys", "log-lab", "ll", "sql-lab", "sql", "sqlformat-lab", "sqlformat", "sqllint", "sqlite-lab", "sqlite", "html-lab", "html", "html-entity-lab", "entity-lab", "entity", "html-entity", "html2md-lab", "html2md", "md2html-lab", "md2html", "xml2json-lab", "xml2json", "json2xml-lab", "json2xml", "csv2xml-lab", "csv2xml", "c2x", "seo-lab", "seo",
+    "filetype-lab", "filetype", "magic-bytes",
     "bencode-lab", "bencode", "torrent",
     "msgpack-lab", "msgpack", "mpack",
     "bson-lab", "bson",
@@ -15746,6 +15747,15 @@ def parse_args(argv=None):
     parser_md2csv.add_argument("--delimiter", "-d", default=",", help="CSV delimiter (default: ',').")
     parser_md2csv.add_argument("--tui", action="store_true", help="Launch the Markdown to CSV TUI.")
 
+    # --- New 'filetype-lab' command ---
+    parser_filetype = subparsers.add_parser(
+        "filetype-lab",
+        aliases=["filetype", "magic-bytes"],
+        help="Detect file types by magic bytes."
+    )
+    parser_filetype.add_argument("file", nargs="?", help="File to detect.")
+    parser_filetype.add_argument("--action", choices=["tui"], help="Action to perform.")
+
     # --- New 'csv2toml-lab' command ---
     parser_csv2xml = subparsers.add_parser(
         "csv2xml-lab",
@@ -24085,6 +24095,13 @@ async def main():
     if args.command in ["csv2toml-lab", "csv2toml", "c2t"]:
         from shared.csv2toml_lab import run_csv2toml_lab_logic
         run_csv2toml_lab_logic(args)
+        return
+
+    if args.command in ["filetype-lab", "filetype", "magic-bytes"]:
+        from shared.filetype_lab import run_filetype_lab_logic
+        success = run_filetype_lab_logic(args)
+        if not success:
+            sys.exit(1)
         return
 
     if args.command in ["csv2xml-lab", "csv2xml", "c2x"]:

--- a/shared/filetype_lab.py
+++ b/shared/filetype_lab.py
@@ -1,0 +1,151 @@
+import sys
+import os
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+# A dictionary of common magic bytes.
+# Keys are bytes objects representing the magic signature.
+# Values are dicts with extension, mime, and description.
+MAGIC_BYTES = {
+    b"\x89PNG\r\n\x1a\n": {"ext": "png", "mime": "image/png", "desc": "PNG image data"},
+    b"\xff\xd8\xff": {"ext": "jpg", "mime": "image/jpeg", "desc": "JPEG image data"},
+    b"GIF87a": {"ext": "gif", "mime": "image/gif", "desc": "GIF image data"},
+    b"GIF89a": {"ext": "gif", "mime": "image/gif", "desc": "GIF image data"},
+    b"%PDF-": {"ext": "pdf", "mime": "application/pdf", "desc": "PDF document"},
+    b"PK\x03\x04": {"ext": "zip", "mime": "application/zip", "desc": "ZIP archive"},
+    b"PK\x05\x06": {"ext": "zip", "mime": "application/zip", "desc": "ZIP archive (empty)"},
+    b"PK\x07\x08": {"ext": "zip", "mime": "application/zip", "desc": "ZIP archive (spanned)"},
+    b"Rar!\x1a\x07\x00": {"ext": "rar", "mime": "application/x-rar-compressed", "desc": "RAR archive v1.50+"},
+    b"Rar!\x1a\x07\x01\x00": {"ext": "rar", "mime": "application/x-rar-compressed", "desc": "RAR archive v5.0+"},
+    b"7z\xbc\xaf\x27\x1c": {"ext": "7z", "mime": "application/x-7z-compressed", "desc": "7-zip archive"},
+    b"\x1f\x8b\x08": {"ext": "gz", "mime": "application/gzip", "desc": "GZIP compressed data"},
+    b"BZh": {"ext": "bz2", "mime": "application/x-bzip2", "desc": "bzip2 compressed data"},
+    b"\xFD7zXZ\x00": {"ext": "xz", "mime": "application/x-xz", "desc": "XZ compressed data"},
+    b"\x04\x22\x4D\x18": {"ext": "lz4", "mime": "application/x-lz4", "desc": "LZ4 compressed data"},
+    b"\x28\xB5\x2F\xFD": {"ext": "zst", "mime": "application/zstd", "desc": "Zstandard compressed data"},
+    b"OggS": {"ext": "ogg", "mime": "application/ogg", "desc": "Ogg multimedia format"},
+    b"fLaC": {"ext": "flac", "mime": "audio/flac", "desc": "FLAC audio data"},
+    b"ID3": {"ext": "mp3", "mime": "audio/mpeg", "desc": "MP3 audio data (ID3v2)"},
+    b"\xFF\xFB": {"ext": "mp3", "mime": "audio/mpeg", "desc": "MP3 audio data"},
+    b"\xFF\xF3": {"ext": "mp3", "mime": "audio/mpeg", "desc": "MP3 audio data"},
+    b"\xFF\xF2": {"ext": "mp3", "mime": "audio/mpeg", "desc": "MP3 audio data"},
+    b"RIFF": {"ext": "wav/avi/webp", "mime": "audio/x-wav", "desc": "RIFF (little-endian) data"},
+    b"\x00\x00\x01\xBA": {"ext": "mpg", "mime": "video/mpeg", "desc": "MPEG video data"},
+    b"\x00\x00\x01\xB3": {"ext": "mpg", "mime": "video/mpeg", "desc": "MPEG video data"},
+    b"\x4D\x5A": {"ext": "exe", "mime": "application/x-msdownload", "desc": "DOS/Windows executable (MZ)"},
+    b"\x7FELF": {"ext": "elf", "mime": "application/x-executable", "desc": "ELF executable"},
+    b"\xCE\xFA\xED\xFE": {"ext": "macho", "mime": "application/x-mach-binary", "desc": "Mach-O binary (32-bit)"},
+    b"\xCF\xFA\xED\xFE": {"ext": "macho", "mime": "application/x-mach-binary", "desc": "Mach-O binary (64-bit)"},
+    b"\xCA\xFE\xBA\xBE": {"ext": "class", "mime": "application/java-vm", "desc": "Java class file / Mach-O universal binary"},
+    b"BM": {"ext": "bmp", "mime": "image/bmp", "desc": "BMP image data"},
+    b"II*\x00": {"ext": "tif", "mime": "image/tiff", "desc": "TIFF image data (little-endian)"},
+    b"MM\x00*": {"ext": "tif", "mime": "image/tiff", "desc": "TIFF image data (big-endian)"},
+    b"{\\rtf1": {"ext": "rtf", "mime": "application/rtf", "desc": "Rich Text Format"},
+    b"SQLite format 3\x00": {"ext": "sqlite", "mime": "application/vnd.sqlite3", "desc": "SQLite 3 database"},
+    b"\x00\x01\x00\x00\x00": {"ext": "ttf", "mime": "font/ttf", "desc": "TrueType font"},
+    b"OTTO": {"ext": "otf", "mime": "font/otf", "desc": "OpenType font"},
+    b"wOFF": {"ext": "woff", "mime": "font/woff", "desc": "WOFF font"},
+    b"wOF2": {"ext": "woff2", "mime": "font/woff2", "desc": "WOFF2 font"},
+    b"#!/bin/bash": {"ext": "sh", "mime": "text/x-shellscript", "desc": "Bash script"},
+    b"#!/bin/sh": {"ext": "sh", "mime": "text/x-shellscript", "desc": "Shell script"},
+    b"#!/usr/bin/env python": {"ext": "py", "mime": "text/x-python", "desc": "Python script"},
+    b"<?xml": {"ext": "xml", "mime": "application/xml", "desc": "XML document"},
+    b"<!DOCTYPE html": {"ext": "html", "mime": "text/html", "desc": "HTML document"},
+    b"\xef\xbb\xbf": {"ext": "txt", "mime": "text/plain", "desc": "UTF-8 encoded text with BOM"},
+}
+
+
+class FileTypeManager:
+    """Manager to detect file types via magic bytes."""
+
+    def detect(self, filepath: str) -> Dict[str, str]:
+        """Reads the first few bytes of a file and detects its type."""
+        path = Path(filepath)
+        if not path.exists():
+            return {"error": f"File '{filepath}' not found."}
+        if not path.is_file():
+            return {"error": f"Path '{filepath}' is not a regular file."}
+
+        try:
+            # We only need the first 32 bytes to identify most magic numbers
+            with open(path, "rb") as f:
+                head = f.read(32)
+        except Exception as e:
+            return {"error": f"Error reading file: {e}"}
+
+        if not head:
+            return {"ext": "", "mime": "application/x-empty", "desc": "Empty file"}
+
+        # Special handling for ISO (CD-ROM)
+        if len(head) >= 32 and b"CD001" in head[25:32] or (len(head)>=32 and head[25:30] == b"CD001"):
+             return {"ext": "iso", "mime": "application/x-iso9660-image", "desc": "ISO 9660 CD-ROM filesystem data"}
+
+        # Simple greedy matching: Find the longest matching magic bytes
+        best_match = None
+        best_len = 0
+
+        for magic, info in MAGIC_BYTES.items():
+            if head.startswith(magic):
+                if len(magic) > best_len:
+                    best_len = len(magic)
+                    best_match = info
+
+        # Additional RIFF detection
+        if head.startswith(b"RIFF") and len(head) >= 12:
+            chunk_type = head[8:12]
+            if chunk_type == b"WAVE":
+                best_match = {"ext": "wav", "mime": "audio/x-wav", "desc": "WAV audio data"}
+            elif chunk_type == b"AVI ":
+                best_match = {"ext": "avi", "mime": "video/x-msvideo", "desc": "AVI video data"}
+            elif chunk_type == b"WEBP":
+                best_match = {"ext": "webp", "mime": "image/webp", "desc": "WebP image data"}
+
+        if best_match:
+            return best_match
+
+        # Text fallback
+        try:
+            head.decode("utf-8")
+            # If it decodes successfully as UTF-8, it might be a text file
+            # Let's check for non-printable characters.
+            if any(b < 9 or (13 < b < 32) for b in head):
+                pass # Probably not standard text
+            else:
+                return {"ext": "txt", "mime": "text/plain", "desc": "Text file (or unknown ASCII/UTF-8 data)"}
+        except UnicodeDecodeError:
+            pass
+
+        return {"ext": "bin", "mime": "application/octet-stream", "desc": "Unknown binary data"}
+
+
+def run_filetype_lab_logic(args) -> bool:
+    """CLI handler for FileType Lab."""
+
+    if getattr(args, "action", None) == "tui":
+        try:
+            from shared.tui import AgentTUI
+            import asyncio
+            app = AgentTUI(project_dir=Path.cwd(), initial_tab="tab-filetype")
+            asyncio.run(app.run_async())
+            return True
+        except ImportError as e:
+            print(f"Error launching TUI: {e}", file=sys.stderr)
+            return False
+
+    manager = FileTypeManager()
+    filepath = getattr(args, "file", None)
+    if not filepath:
+        print("Error: A file path is required.", file=sys.stderr)
+        return False
+
+    result = manager.detect(filepath)
+    if "error" in result:
+        print(f"Error: {result['error']}", file=sys.stderr)
+        return False
+
+    print(f"File: {filepath}")
+    print(f"Extension: {result.get('ext', 'N/A')}")
+    print(f"MIME Type: {result.get('mime', 'N/A')}")
+    print(f"Description: {result.get('desc', 'N/A')}")
+
+    return True

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -334,6 +334,7 @@ from shared.tui_sqlformat import TabSqlFormat
 from shared.plugin_manager import PluginManager
 from shared.tui_regex_escape import RegexEscapeLabTab
 from shared.tui_fuzz import FuzzLabTab
+from shared.tui_filetype import FileTypeLabTab
 
 
 # Helper to get Git info safely
@@ -4883,6 +4884,8 @@ class AgentTUI(App):
                 yield RegexEscapeLabTab()
             with TabPane("Fuzz Lab", id="tab-fuzz"):
                 yield FuzzLabTab(self.project_dir)
+            with TabPane("FileType Lab", id="tab-filetype"):
+                yield FileTypeLabTab()
             with TabPane("SRI Lab", id="tab-sri"):
                 yield SriLabTab()
             with TabPane("OpenAPI Lab", id="tab-openapi"):

--- a/shared/tui_filetype.py
+++ b/shared/tui_filetype.py
@@ -1,0 +1,51 @@
+from textual.app import ComposeResult
+from textual.containers import Container, Vertical, Horizontal
+from textual.widgets import Label, Button, Input, Static
+from textual import on
+from shared.filetype_lab import FileTypeManager
+
+class FileTypeLabTab(Container):
+    """Tab for FileType Lab (detect file types using magic bytes)."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.manager = FileTypeManager()
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="p-4"):
+            yield Label("[bold]FileType Lab (Magic Bytes)[/bold]", classes="welcome-text mb-4")
+
+            with Horizontal(classes="mb-4"):
+                yield Label("File Path: ", classes="mr-2 mt-1")
+                yield Input(placeholder="/path/to/file", id="input-filepath")
+                yield Button("Detect", id="btn-detect", variant="primary", classes="ml-2")
+
+            with Vertical(id="result-container", classes="stat-box p-4"):
+                yield Static(id="output-result")
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-detect":
+            self.detect_file()
+
+    async def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "input-filepath":
+            self.detect_file()
+
+    def detect_file(self) -> None:
+        filepath = self.query_one("#input-filepath", Input).value.strip()
+        output_widget = self.query_one("#output-result", Static)
+
+        if not filepath:
+            output_widget.update("[red]Error: Please enter a file path.[/red]")
+            return
+
+        result = self.manager.detect(filepath)
+
+        if "error" in result:
+            output_widget.update(f"[red]{result['error']}[/red]")
+        else:
+            output = f"[bold green]File detected![/bold green]\n\n"
+            output += f"[bold]Extension:[/bold] {result.get('ext', 'N/A')}\n"
+            output += f"[bold]MIME Type:[/bold] {result.get('mime', 'N/A')}\n"
+            output += f"[bold]Description:[/bold] {result.get('desc', 'N/A')}"
+            output_widget.update(output)

--- a/tests/test_filetype_lab.py
+++ b/tests/test_filetype_lab.py
@@ -1,0 +1,79 @@
+import pytest
+import os
+from pathlib import Path
+from shared.filetype_lab import FileTypeManager
+from argparse import Namespace
+from shared.filetype_lab import run_filetype_lab_logic
+
+@pytest.fixture
+def manager():
+    return FileTypeManager()
+
+def test_detect_png(manager, tmp_path):
+    f = tmp_path / "test.png"
+    f.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\x0D")
+    result = manager.detect(str(f))
+    assert result["ext"] == "png"
+    assert result["mime"] == "image/png"
+
+def test_detect_jpeg(manager, tmp_path):
+    f = tmp_path / "test.jpg"
+    f.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01")
+    result = manager.detect(str(f))
+    assert result["ext"] == "jpg"
+    assert result["mime"] == "image/jpeg"
+
+def test_detect_pdf(manager, tmp_path):
+    f = tmp_path / "test.pdf"
+    f.write_bytes(b"%PDF-1.4\n")
+    result = manager.detect(str(f))
+    assert result["ext"] == "pdf"
+    assert result["mime"] == "application/pdf"
+
+def test_detect_zip(manager, tmp_path):
+    f = tmp_path / "test.zip"
+    f.write_bytes(b"PK\x03\x04\n\x00\x00\x00")
+    result = manager.detect(str(f))
+    assert result["ext"] == "zip"
+    assert result["mime"] == "application/zip"
+
+def test_detect_txt(manager, tmp_path):
+    f = tmp_path / "test.txt"
+    f.write_bytes(b"Hello world, this is a simple text file.")
+    result = manager.detect(str(f))
+    assert result["ext"] == "txt"
+    assert result["mime"] == "text/plain"
+
+def test_detect_bin(manager, tmp_path):
+    f = tmp_path / "test.bin"
+    # Some random binary data that is not text and doesn't match any known magic bytes
+    f.write_bytes(b"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D")
+    result = manager.detect(str(f))
+    assert result["ext"] == "bin"
+    assert result["mime"] == "application/octet-stream"
+
+def test_detect_empty(manager, tmp_path):
+    f = tmp_path / "test.empty"
+    f.write_bytes(b"")
+    result = manager.detect(str(f))
+    assert result["ext"] == ""
+    assert result["mime"] == "application/x-empty"
+
+def test_detect_not_found(manager):
+    result = manager.detect("/path/that/does/not/exist.xyz")
+    assert "error" in result
+
+def test_run_filetype_lab_logic(tmp_path, capsys):
+    f = tmp_path / "test.pdf"
+    f.write_bytes(b"%PDF-1.4\n")
+    args = Namespace(file=str(f), action=None)
+    assert run_filetype_lab_logic(args) is True
+    out, _ = capsys.readouterr()
+    assert "Extension: pdf" in out
+    assert "MIME Type: application/pdf" in out
+
+def test_run_filetype_lab_logic_error(capsys):
+    args = Namespace(file="/invalid/path", action=None)
+    assert run_filetype_lab_logic(args) is False
+    _, err = capsys.readouterr()
+    assert "Error:" in err


### PR DESCRIPTION
Implemented a new FileType Lab which enables users to detect file types securely by inspecting the first few bytes (magic bytes). This is especially useful for files that have no extension or the wrong extension. Added a robust CLI interface and an interactive TUI tab. Also included comprehensive unit tests in `tests/test_filetype_lab.py`.

---
*PR created automatically by Jules for task [14380099114025181379](https://jules.google.com/task/14380099114025181379) started by @process-failed-successfully*