### PR TITLE
feat: Add Zstandard Compression Lab

### DIFF
--- a/main.py
+++ b/main.py
@@ -351,7 +351,7 @@ KNOWN_COMMANDS = [
     "base64img-lab", "base64img", "b64img",
     "base64url-lab", "base64url", "b64url",
     "zlib-lab", "zlib", "compress", "inflate",
-    "brotli-lab", "brotli",
+    "brotli-lab", "brotli", "zstd-lab", "zstd",
     "base85-lab", "base85", "b85",
     "base91-lab", "base91", "b91",
     "base92-lab", "base92", "b92",
@@ -978,6 +978,25 @@ def run_brotli_lab(args):
 
     from shared.brotli_lab import run_brotli_lab_logic
     success = run_brotli_lab_logic(args)
+    sys.exit(0 if success else 1)
+
+
+def run_zstd_lab(args):
+    """Runs the Zstandard Lab."""
+    if getattr(args, "tui", False):
+        from shared.tui import AgentTUI
+        print("Launching Zstandard Lab TUI...")
+        app = AgentTUI(project_dir=getattr(args, 'project_dir', None), start_tab="tab-zstd")
+        app.run()
+        sys.exit(0)
+
+    # Logic path
+    if getattr(args, "compress", None) is None and getattr(args, "decompress", None) is None:
+        print("Error: must provide either --compress, --decompress, or --tui", file=sys.stderr)
+        sys.exit(1)
+
+    from shared.zstd_lab import run_zstd_lab_logic
+    success = run_zstd_lab_logic(args)
     sys.exit(0 if success else 1)
 
 
@@ -17483,6 +17502,19 @@ Examples:
     parser_brotli.add_argument("--quality", "-q", type=int, choices=range(0, 12), default=11, help="Compression quality (0-11, default: 11).")
     parser_brotli.add_argument("--base64", "-b", action="store_true", help="Use base64 instead of hex for outputting/reading compressed data.")
 
+
+    # zstd-lab
+    parser_zstd = subparsers.add_parser(
+        "zstd-lab", aliases=["zstd"],
+        help="Compress and decompress data using Zstandard."
+    )
+    zstd_group = parser_zstd.add_mutually_exclusive_group(required=False)
+    zstd_group.add_argument("--compress", "-c", type=str, help="Text to compress.")
+    zstd_group.add_argument("--decompress", "-d", type=str, help="Data to decompress.")
+    zstd_group.add_argument("--tui", action="store_true", help="Launch the interactive Zstandard Lab TUI.")
+    parser_zstd.add_argument("--level", "-l", type=int, choices=range(1, 23), default=3, help="Compression level (1-22, default: 3).")
+    parser_zstd.add_argument("--base64", "-b", action="store_true", help="Use base64 instead of hex for outputting/reading compressed data.")
+
     parser_b64url = subparsers.add_parser(
         "base64url-lab", aliases=["base64url", "b64url"],
         help="Base64URL encode and decode strings."
@@ -24392,6 +24424,8 @@ async def main():
 
     if args.command in ["brotli-lab", "brotli"]:
         run_brotli_lab(args)
+    if args.command in ["zstd-lab", "zstd"]:
+        run_zstd_lab(args)
         return
 
     if args.command in ["base64url-lab", "base64url", "b64url"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "cbor2",
     "msgpack",
     "brotli",
+    "zstandard",
     "python-gnupg>=0.5.0",
     "jmespath>=1.0.1",
     "jq>=1.11.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,4 @@ idna
 brotli
 python-gnupg>=0.5.0
 jmespath>=1.0.1
+zstandard

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -192,6 +192,7 @@ from shared.tui_slug import SlugLabTab
 from shared.tui_arn import ArnLabTab
 from shared.tui_bcrypt import BcryptLabTab
 from shared.tui_brotli import BrotliLabTab
+from shared.tui_zstd import ZstdLabTab
 from shared.tui_base91 import Base91LabTab
 from shared.tui_base92 import Base92LabTab
 from shared.tui_base64 import Base64LabTab
@@ -4159,6 +4160,7 @@ class AgentTUI(App):
         PaletteCommand("Go to Luhn Lab", "switch_tab_luhn"),
         PaletteCommand("Go to Bcrypt Lab", "switch_tab_bcrypt"),
         PaletteCommand("Go to Brotli Lab", "switch_tab_brotli"),
+        PaletteCommand("Go to Zstd Lab", "switch_tab_zstd"),
         PaletteCommand("Go to IBAN Lab", "switch_tab_iban"),
         PaletteCommand("Go to Data URI Lab", "switch_tab_data_uri"),
         PaletteCommand("Go to Geo Lab", "switch_tab_geo"),
@@ -4611,6 +4613,8 @@ class AgentTUI(App):
                 yield ZlibTab()
             with TabPane("Brotli Lab", id="tab-brotli"):
                 yield BrotliLabTab()
+            with TabPane("Zstd Lab", id="tab-zstd"):
+                yield ZstdLabTab()
 
             with TabPane("Bcrypt Lab", id="tab-bcrypt"):
                 yield BcryptLabTab()

--- a/shared/tui_zstd.py
+++ b/shared/tui_zstd.py
@@ -1,0 +1,101 @@
+from textual.app import ComposeResult
+from textual.containers import Container, Vertical
+from textual.widgets import Label, TextArea, Checkbox, Select
+from textual import on
+
+from shared.zstd_lab import ZstdLabManager
+import base64
+
+
+class ZstdLabTab(Container):
+    """Tab for Zstandard compression and decompression."""
+
+    def __init__(self):
+        super().__init__()
+        self.manager = ZstdLabManager()
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="zstd-container"):
+            yield Label("[bold]Zstandard Compression Lab[/bold]", classes="welcome-text")
+
+            with Vertical(classes="zstd-controls"):
+                # Zstandard compression levels are usually 1 to 22. Default is 3.
+                level_options = [(str(i), i) for i in range(1, 23)]
+                yield Select(options=level_options, id="zstd-level", value=3)
+                yield Checkbox("Base64 Output/Input (instead of Hex)", id="zstd-base64", value=True)
+
+            with Vertical(classes="zstd-panels"):
+                with Vertical(classes="zstd-panel"):
+                    yield Label("Uncompressed Text:")
+                    yield TextArea(id="zstd-input-text")
+
+                with Vertical(classes="zstd-panel"):
+                    yield Label("Compressed Payload (Hex or Base64):")
+                    yield TextArea(id="zstd-compressed-text")
+
+    @on(TextArea.Changed, "#zstd-input-text")
+    def on_input_text_changed(self, event: TextArea.Changed) -> None:
+        """When the user types uncompressed text, compress it."""
+        if not event.text_area.has_focus:
+            return
+        input_text = self.query_one("#zstd-input-text", TextArea).text
+        if not input_text:
+            self.query_one("#zstd-compressed-text", TextArea).text = ""
+            return
+
+        level = self.query_one("#zstd-level", Select).value
+        # If the level select isn't ready yet or holds an invalid value, fallback
+        if level is None or level is Select.BLANK:
+            level = 3
+
+        use_base64 = self.query_one("#zstd-base64", Checkbox).value
+
+        try:
+            compressed = self.manager.compress(input_text.encode('utf-8'), level=level)
+            if use_base64:
+                out_str = base64.b64encode(compressed).decode('ascii')
+            else:
+                out_str = compressed.hex()
+            self.query_one("#zstd-compressed-text", TextArea).text = out_str
+        except Exception as e:
+            self.query_one("#zstd-compressed-text", TextArea).text = f"Error: {e}"
+
+    @on(TextArea.Changed, "#zstd-compressed-text")
+    def on_compressed_text_changed(self, event: TextArea.Changed) -> None:
+        """When the user modifies the compressed data, try to decompress it."""
+        if not event.text_area.has_focus:
+            return
+        compressed_text = self.query_one("#zstd-compressed-text", TextArea).text.strip()
+        if not compressed_text:
+            self.query_one("#zstd-input-text", TextArea).text = ""
+            return
+
+        use_base64 = self.query_one("#zstd-base64", Checkbox).value
+
+        try:
+            if use_base64:
+                data = base64.b64decode(compressed_text)
+            else:
+                data = bytes.fromhex(compressed_text)
+
+            decompressed = self.manager.decompress(data)
+            self.query_one("#zstd-input-text", TextArea).text = decompressed.decode('utf-8')
+        except Exception as e:
+            # Optionally show an error somewhere, but typical in these TUI tools is to just not update
+            # the other pane if it's currently invalid hex/base64 or not fully pasted.
+            pass
+
+    @on(Select.Changed, "#zstd-level")
+    @on(Checkbox.Changed, "#zstd-base64")
+    def on_settings_changed(self) -> None:
+        """When settings change, trigger re-compression if there's input text."""
+        # Just simulate a change on the input text to re-trigger compression
+        input_area = self.query_one("#zstd-input-text", TextArea)
+        if input_area.text:
+            # Only trigger if it has text, to avoid clearing error states needlessly
+            # We artificially focus it for the event check
+            was_focused = input_area.has_focus
+            input_area.focus()
+            self.on_input_text_changed(TextArea.Changed(input_area))
+            if not was_focused:
+                self.query_one("#zstd-base64", Checkbox).focus()

--- a/shared/zstd_lab.py
+++ b/shared/zstd_lab.py
@@ -1,0 +1,58 @@
+import argparse
+import base64
+import sys
+import zstandard as zstd
+
+class ZstdLabManager:
+    """Manages Zstandard compression and decompression operations."""
+
+    def compress(self, data: bytes, level: int = 3) -> bytes:
+        """
+        Compresses the given data using Zstandard.
+        Level typically ranges from 1 to 22 (default is 3).
+        """
+        compressor = zstd.ZstdCompressor(level=level)
+        return compressor.compress(data)
+
+    def decompress(self, data: bytes) -> bytes:
+        """
+        Decompresses the given Zstandard-compressed data.
+        """
+        decompressor = zstd.ZstdDecompressor()
+        return decompressor.decompress(data)
+
+def run_zstd_lab_logic(args: argparse.Namespace) -> bool:
+    try:
+        manager = ZstdLabManager()
+
+        if getattr(args, "compress", None) is not None:
+            text = args.compress.encode("utf-8")
+            compressed = manager.compress(text, level=args.level)
+            if args.base64:
+                print(base64.b64encode(compressed).decode("ascii"))
+            else:
+                print(compressed.hex())
+        elif getattr(args, "decompress", None) is not None:
+            if args.base64:
+                try:
+                    data = base64.b64decode(args.decompress)
+                except Exception as e:
+                    print(f"Error decoding base64: {e}", file=sys.stderr)
+                    return False
+            else:
+                try:
+                    data = bytes.fromhex(args.decompress)
+                except Exception as e:
+                    print(f"Error decoding hex: {e}", file=sys.stderr)
+                    return False
+
+            decompressed = manager.decompress(data)
+            print(decompressed.decode("utf-8"))
+        else:
+            print("Error: must provide either --compress, --decompress, or --tui", file=sys.stderr)
+            return False
+
+        return True
+    except Exception as e:
+        print(f"Error processing zstd: {e}", file=sys.stderr)
+        return False

--- a/tests/test_tui_zstd.py
+++ b/tests/test_tui_zstd.py
@@ -1,0 +1,63 @@
+import unittest
+import base64
+import pytest
+from textual.app import App
+from textual.widgets import TextArea, Checkbox, Select
+
+from shared.tui_zstd import ZstdLabTab
+
+class ZstdTestApp(App):
+    def compose(self):
+        yield ZstdLabTab()
+
+class TestTuiZstd(unittest.IsolatedAsyncioTestCase):
+    @pytest.mark.asyncio
+    async def test_zstd_tab_compression_hex(self):
+        app = ZstdTestApp()
+        async with app.run_test() as pilot:
+            tab = app.query_one(ZstdLabTab)
+
+            # Switch base64 to False
+            cb = tab.query_one("#zstd-base64", Checkbox)
+            cb.value = False
+            await pilot.pause()
+
+            # Enter text to compress
+            input_area = tab.query_one("#zstd-input-text", TextArea)
+            input_area.focus()
+            input_area.text = "Hello Zstandard"
+            await pilot.pause()
+
+            # Check compressed output
+            compressed_area = tab.query_one("#zstd-compressed-text", TextArea)
+            out_hex = compressed_area.text.strip()
+            self.assertTrue(len(out_hex) > 0)
+            self.assertTrue(all(c in "0123456789abcdefABCDEF" for c in out_hex))
+
+    @pytest.mark.asyncio
+    async def test_zstd_tab_compression_base64(self):
+        app = ZstdTestApp()
+        async with app.run_test() as pilot:
+            tab = app.query_one(ZstdLabTab)
+
+            # Base64 is default True
+            cb = tab.query_one("#zstd-base64", Checkbox)
+            self.assertTrue(cb.value)
+
+            # Enter text to compress
+            input_area = tab.query_one("#zstd-input-text", TextArea)
+            input_area.focus()
+            input_area.text = "Hello Zstandard"
+            await pilot.pause()
+
+            # Check compressed output
+            compressed_area = tab.query_one("#zstd-compressed-text", TextArea)
+            out_b64 = compressed_area.text.strip()
+            self.assertTrue(len(out_b64) > 0)
+
+            # Verify valid base64
+            decoded = base64.b64decode(out_b64)
+            self.assertTrue(len(decoded) > 0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_zstd_lab.py
+++ b/tests/test_zstd_lab.py
@@ -1,0 +1,69 @@
+import unittest
+import argparse
+import base64
+import io
+from unittest.mock import patch
+
+from shared.zstd_lab import ZstdLabManager, run_zstd_lab_logic
+
+class TestZstdLabManager(unittest.TestCase):
+    def setUp(self):
+        self.manager = ZstdLabManager()
+        self.test_data = b"Hello, Zstandard Compression!"
+
+    def test_compress_decompress_default(self):
+        compressed = self.manager.compress(self.test_data)
+        self.assertNotEqual(compressed, self.test_data)
+        self.assertTrue(len(compressed) > 0)
+
+        decompressed = self.manager.decompress(compressed)
+        self.assertEqual(decompressed, self.test_data)
+
+    def test_compress_decompress_level(self):
+        # Using a very high compression level just to see it doesn't fail
+        compressed = self.manager.compress(self.test_data, level=10)
+        self.assertNotEqual(compressed, self.test_data)
+
+        decompressed = self.manager.decompress(compressed)
+        self.assertEqual(decompressed, self.test_data)
+
+
+class TestZstdLabLogic(unittest.TestCase):
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_run_compress_hex(self, mock_stdout):
+        args = argparse.Namespace(compress="test text", decompress=None, level=3, base64=False, tui=False)
+        self.assertTrue(run_zstd_lab_logic(args))
+        output = mock_stdout.getvalue().strip()
+        self.assertTrue(all(c in "0123456789abcdefABCDEF" for c in output))
+        self.assertTrue(len(output) > 0)
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_run_compress_base64(self, mock_stdout):
+        args = argparse.Namespace(compress="test text", decompress=None, level=3, base64=True, tui=False)
+        self.assertTrue(run_zstd_lab_logic(args))
+        output = mock_stdout.getvalue().strip()
+        decoded = base64.b64decode(output)
+        self.assertTrue(len(decoded) > 0)
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_run_decompress_hex(self, mock_stdout):
+        manager = ZstdLabManager()
+        compressed = manager.compress(b"test text")
+        hex_data = compressed.hex()
+
+        args = argparse.Namespace(compress=None, decompress=hex_data, level=3, base64=False, tui=False)
+        self.assertTrue(run_zstd_lab_logic(args))
+        self.assertEqual(mock_stdout.getvalue().strip(), "test text")
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_run_decompress_base64(self, mock_stdout):
+        manager = ZstdLabManager()
+        compressed = manager.compress(b"test text")
+        b64_data = base64.b64encode(compressed).decode("ascii")
+
+        args = argparse.Namespace(compress=None, decompress=b64_data, level=3, base64=True, tui=False)
+        self.assertTrue(run_zstd_lab_logic(args))
+        self.assertEqual(mock_stdout.getvalue().strip(), "test text")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces the new `zstd-lab` command line tool and TUI component for interacting with the Zstandard compression algorithm. Zstandard provides a modern, fast compression algorithm that complements our existing Brotli and Zlib offerings.

Users can quickly compress or decompress strings and payloads in both Hex and Base64 format via the command line or via the interactive Terminal User Interface (TUI). 

Test coverage was included for both the CLI arguments/backend manager and the Textual TUI elements.

---
*PR created automatically by Jules for task [11283476910362677871](https://jules.google.com/task/11283476910362677871) started by @process-failed-successfully*