### PR TITLE
Add TUI for Whois Lab

### DIFF
--- a/main.py
+++ b/main.py
@@ -2704,6 +2704,12 @@ def run_dns_lab(args):
 
 def run_whois_lab(args):
     """Runs the Whois Lab."""
+    if hasattr(args, "tui") and args.tui:
+        run_tui(args, start_tab="tab-whois")
+        return
+    if not hasattr(args, 'action') or not args.action:
+        print("Error: Action is required unless --tui is specified.", file=sys.stderr)
+        sys.exit(1)
     run_whois_lab_logic(args)
     sys.exit(0)
 
@@ -18268,9 +18274,10 @@ Examples:
         aliases=["whois"],
         help="Whois utilities (lookup, check)."
     )
+    parser_whois.add_argument("--tui", action="store_true", help="Launch the interactive Whois Lab TUI.")
     whois_subparsers = parser_whois.add_subparsers(
         dest="action",
-        required=True,
+        required=False,
         help="Action to perform."
     )
 

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -303,6 +303,7 @@ from shared.tui_uni import UniLabTab
 from shared.tui_vcard import VCardTab
 from shared.tui_curl import CurlLabTab
 from shared.tui_portscan import PortScanTab
+from shared.tui_whois import WhoisLabTab
 from shared.tui_html2md import Html2MdTab
 from shared.tui_html2jsx import Html2JsxLabTab
 from shared.tui_fs import FsLabTab
@@ -4760,6 +4761,9 @@ class AgentTUI(App):
                 yield DiagramLabTab(self.project_dir)
             with TabPane("HTML2MD Lab", id="tab-html2md"):
                 yield Html2MdTab()
+
+            with TabPane("Whois Lab", id="tab-whois"):
+                yield WhoisLabTab()
 
             with TabPane("XML to CSV", id="tab-xml2csv"):
                 yield Xml2CsvTab()

--- a/shared/tui_whois.py
+++ b/shared/tui_whois.py
@@ -1,0 +1,90 @@
+import asyncio
+from textual.app import ComposeResult
+from textual.containers import Vertical, Horizontal
+from textual.widgets import Input, Button, Label, RichLog, Static
+from textual.reactive import reactive
+from shared.whois_lab import WhoisLabManager
+
+class WhoisLabTab(Vertical):
+    """TUI Tab for Whois Lab."""
+
+    is_querying = reactive(False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.manager = WhoisLabManager()
+
+    def compose(self) -> ComposeResult:
+        yield Label("Whois Lab", classes="tab-title")
+        yield Label("Perform WHOIS lookups and check domain availability.", classes="tab-description")
+
+        with Horizontal(id="whois-inputs-container"):
+            yield Input(placeholder="Domain (e.g., example.com)", id="whois-domain")
+            yield Input(placeholder="Optional Server (e.g., whois.iana.org)", id="whois-server")
+            yield Button("Lookup", id="btn-whois-lookup", variant="primary")
+            yield Button("Check Availability", id="btn-whois-check", variant="success")
+
+        yield Label("", id="whois-status")
+
+        # Use RichLog to allow scrolling
+        self.output_log = RichLog(id="whois-output-log", markup=True, highlight=True, wrap=True)
+        yield self.output_log
+
+    def watch_is_querying(self, is_querying: bool) -> None:
+        """Update UI based on querying state."""
+        self.query_one("#btn-whois-lookup", Button).disabled = is_querying
+        self.query_one("#btn-whois-check", Button).disabled = is_querying
+        self.query_one("#whois-domain", Input).disabled = is_querying
+        self.query_one("#whois-server", Input).disabled = is_querying
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-whois-lookup":
+            await self.action_lookup()
+        elif event.button.id == "btn-whois-check":
+            await self.action_check()
+
+    async def action_lookup(self) -> None:
+        domain = self.query_one("#whois-domain", Input).value.strip()
+        server = self.query_one("#whois-server", Input).value.strip()
+
+        if not domain:
+            self.notify("Please enter a domain.", title="Error", severity="error")
+            return
+
+        self.is_querying = True
+        status_lbl = self.query_one("#whois-status", Label)
+        status_lbl.update(f"Looking up {domain}...")
+        self.output_log.clear()
+
+        # Run lookup in thread to not block UI
+        result = await asyncio.to_thread(self.manager.lookup, domain, server if server else None)
+
+        self.output_log.write(result)
+        status_lbl.update(f"Lookup complete for {domain}.")
+        self.is_querying = False
+
+    async def action_check(self) -> None:
+        domain = self.query_one("#whois-domain", Input).value.strip()
+
+        if not domain:
+            self.notify("Please enter a domain.", title="Error", severity="error")
+            return
+
+        self.is_querying = True
+        status_lbl = self.query_one("#whois-status", Label)
+        status_lbl.update(f"Checking availability for {domain}...")
+        self.output_log.clear()
+
+        # Run check in thread to not block UI
+        result = await asyncio.to_thread(self.manager.check_availability, domain)
+
+        if result["available"]:
+            status_lbl.update(f"✅ Domain '{domain}' appears to be AVAILABLE.")
+            self.notify(f"Domain '{domain}' appears to be AVAILABLE.", title="Whois Check", severity="information")
+        else:
+            status_lbl.update(f"❌ Domain '{domain}' appears to be TAKEN (or status unknown).")
+            self.notify(f"Domain '{domain}' appears to be TAKEN.", title="Whois Check", severity="warning")
+
+        self.output_log.write("\n--- Raw Output ---\n")
+        self.output_log.write(result["output"])
+        self.is_querying = False

--- a/tests/test_tui_whois.py
+++ b/tests/test_tui_whois.py
@@ -1,0 +1,115 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from textual.widgets import Input, Button, Label, RichLog
+import pytest
+
+from shared.tui_whois import WhoisLabTab
+
+class TestWhoisLabTab(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.patcher = patch("shared.tui_whois.WhoisLabManager")
+        self.MockManager = self.patcher.start()
+
+        self.tab = WhoisLabTab()
+        self.mock_manager = self.MockManager.return_value
+        self.tab.manager = self.mock_manager
+
+        self.tab.notify = MagicMock()
+        self.tab.query_one = MagicMock()
+
+    async def asyncTearDown(self):
+        self.patcher.stop()
+
+    async def test_action_lookup_success(self):
+        domain_input = MagicMock(spec=Input)
+        domain_input.value = "example.com"
+        server_input = MagicMock(spec=Input)
+        server_input.value = ""
+        status_lbl = MagicMock(spec=Label)
+
+        self.tab.query_one.side_effect = lambda selector, _: {
+            "#whois-domain": domain_input,
+            "#whois-server": server_input,
+            "#whois-status": status_lbl,
+            "#btn-whois-lookup": MagicMock(),
+            "#btn-whois-check": MagicMock()
+        }[selector]
+
+        self.tab.output_log = MagicMock(spec=RichLog)
+        self.mock_manager.lookup.return_value = "Mock WHOIS info for example.com"
+
+        await self.tab.action_lookup()
+
+        self.mock_manager.lookup.assert_called_once_with("example.com", None)
+        self.tab.output_log.write.assert_called_once_with("Mock WHOIS info for example.com")
+        status_lbl.update.assert_called_with("Lookup complete for example.com.")
+        self.assertFalse(self.tab.is_querying)
+
+    async def test_action_lookup_no_domain(self):
+        domain_input = MagicMock(spec=Input)
+        domain_input.value = ""
+        server_input = MagicMock(spec=Input)
+        server_input.value = ""
+
+        self.tab.query_one.side_effect = lambda selector, _: {
+            "#whois-domain": domain_input,
+            "#whois-server": server_input
+        }[selector]
+
+        await self.tab.action_lookup()
+
+        self.tab.notify.assert_called_once_with("Please enter a domain.", title="Error", severity="error")
+        self.mock_manager.lookup.assert_not_called()
+
+    async def test_action_check_available(self):
+        domain_input = MagicMock(spec=Input)
+        domain_input.value = "example.xyz"
+        status_lbl = MagicMock(spec=Label)
+
+        self.tab.query_one.side_effect = lambda selector, _: {
+            "#whois-domain": domain_input,
+            "#whois-status": status_lbl,
+            "#btn-whois-lookup": MagicMock(),
+            "#btn-whois-check": MagicMock(),
+            "#whois-server": MagicMock()
+        }[selector]
+
+        self.tab.output_log = MagicMock(spec=RichLog)
+        self.mock_manager.check_availability.return_value = {
+            "available": True,
+            "output": "Domain is free"
+        }
+
+        await self.tab.action_check()
+
+        self.mock_manager.check_availability.assert_called_once_with("example.xyz")
+        status_lbl.update.assert_called_with("✅ Domain 'example.xyz' appears to be AVAILABLE.")
+        self.tab.notify.assert_called_with("Domain 'example.xyz' appears to be AVAILABLE.", title="Whois Check", severity="information")
+        self.tab.output_log.write.assert_any_call("Domain is free")
+
+    async def test_action_check_taken(self):
+        domain_input = MagicMock(spec=Input)
+        domain_input.value = "google.com"
+        status_lbl = MagicMock(spec=Label)
+
+        self.tab.query_one.side_effect = lambda selector, _: {
+            "#whois-domain": domain_input,
+            "#whois-status": status_lbl,
+            "#btn-whois-lookup": MagicMock(),
+            "#btn-whois-check": MagicMock(),
+            "#whois-server": MagicMock()
+        }[selector]
+
+        self.tab.output_log = MagicMock(spec=RichLog)
+        self.mock_manager.check_availability.return_value = {
+            "available": False,
+            "output": "Domain is taken"
+        }
+
+        await self.tab.action_check()
+
+        self.mock_manager.check_availability.assert_called_once_with("google.com")
+        status_lbl.update.assert_called_with("❌ Domain 'google.com' appears to be TAKEN (or status unknown).")
+        self.tab.notify.assert_called_with("Domain 'google.com' appears to be TAKEN.", title="Whois Check", severity="warning")
+        self.tab.output_log.write.assert_any_call("Domain is taken")


### PR DESCRIPTION
This submission introduces a user-friendly TUI for the Whois Lab feature. It provides input fields for domains and optional server overrides, and buttons to either perform a full WHOIS lookup or simply check domain availability. The TUI manages its own state by leveraging async calls to not freeze the interface while performing network operations. Corresponding updates have been made to the CLI in `main.py` to trigger the TUI via the `--tui` flag. Comprehensive unit tests are included for the UI interactions.

---
*PR created automatically by Jules for task [3791047169125308338](https://jules.google.com/task/3791047169125308338) started by @process-failed-successfully*