### PR TITLE
fix(tests): skip textual imports in test_tui_whois if textual is missing

### DIFF
--- a/tests/test_tui_whois.py
+++ b/tests/test_tui_whois.py
@@ -1,8 +1,10 @@
 import unittest
 from unittest.mock import MagicMock, patch
-from textual.widgets import Input, Button, Label, RichLog
 import pytest
 
+pytest.importorskip("textual")
+
+from textual.widgets import Input, Button, Label, RichLog
 from shared.tui_whois import WhoisLabTab
 
 class TestWhoisLabTab(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
Added `pytest.importorskip("textual")` to `tests/test_tui_whois.py` to prevent `ModuleNotFoundError` during test collection in environments where the optional `textual` dependency is not installed.

---
*PR created automatically by Jules for task [1860419358263580706](https://jules.google.com/task/1860419358263580706) started by @process-failed-successfully*