### PR TITLE
feat(crypto-lab): Add HMAC generation support

### DIFF
--- a/main.py
+++ b/main.py
@@ -16242,6 +16242,14 @@ def parse_args(argv=None):
     parser_crypto_hash.add_argument("--file", help="Input file.")
     parser_crypto_hash.add_argument("--algo", default="sha256", help="Algorithm (md5, sha1, sha256, sha512).")
 
+    # crypto-lab hmac
+    parser_crypto_hmac = crypto_subparsers.add_parser("hmac", help="Calculate HMAC.")
+    parser_crypto_hmac.add_argument("--text", help="Input text.")
+    parser_crypto_hmac.add_argument("--file", help="Input file.")
+    parser_crypto_hmac.add_argument("--key", help="Key string.")
+    parser_crypto_hmac.add_argument("--key-file", help="Key file.")
+    parser_crypto_hmac.add_argument("--algo", default="sha256", help="Algorithm (md5, sha1, sha256, sha512).")
+
     # crypto-lab gen-key
     parser_crypto_gen = crypto_subparsers.add_parser("gen-key", help="Generate encryption key.")
     parser_crypto_gen.add_argument("--output", "-o", help="Save key to file.")

--- a/shared/crypto_lab.py
+++ b/shared/crypto_lab.py
@@ -1,6 +1,7 @@
 import hashlib
 import uuid
 import secrets
+import hmac
 import base64
 import sys
 from pathlib import Path
@@ -37,6 +38,29 @@ class CryptoLabManager:
         hasher = hashlib.new(algo)
         hasher.update(data_bytes)
         return hasher.hexdigest()
+
+    def hmac_data(self, input_data: Union[str, bytes], key: Union[str, bytes], algo: str = "sha256") -> str:
+        """
+        Calculates the HMAC digest of the input data using the specified key.
+        Supported algorithms: md5, sha1, sha256, sha512.
+        """
+        if isinstance(input_data, str):
+            data_bytes = input_data.encode("utf-8")
+        else:
+            data_bytes = input_data
+
+        if isinstance(key, str):
+            key_bytes = key.encode("utf-8")
+        else:
+            key_bytes = key
+
+        algo = algo.lower()
+        if algo not in hashlib.algorithms_available:
+            if algo not in ["md5", "sha1", "sha256", "sha512"]:
+                raise ValueError(f"Unsupported algorithm: {algo}")
+
+        mac = hmac.new(key_bytes, data_bytes, getattr(hashlib, algo))
+        return mac.hexdigest()
 
     def generate_key(self) -> bytes:
         """Generates a Fernet key."""
@@ -203,6 +227,44 @@ def run_crypto_lab_logic(args) -> bool:
                     return False
 
             result = manager.hash_data(data, args.algo)
+            print(result)
+            return True
+
+        elif args.action == "hmac":
+            data = None
+            if args.file:
+                path = Path(args.file)
+                if not path.exists():
+                    print(f"Error: File {path} not found.", file=sys.stderr)
+                    return False
+                data = path.read_bytes()
+            elif args.text:
+                data = args.text
+            else:
+                # Read from stdin
+                if not sys.stdin.isatty():
+                    try:
+                        data = sys.stdin.buffer.read()
+                    except Exception:
+                        data = sys.stdin.read().encode("utf-8")
+                else:
+                    print("Error: Input text or file required.", file=sys.stderr)
+                    return False
+
+            key = None
+            if args.key:
+                key = args.key
+            elif args.key_file:
+                path = Path(args.key_file)
+                if not path.exists():
+                    print(f"Error: Key file {path} not found.", file=sys.stderr)
+                    return False
+                key = path.read_bytes()
+            else:
+                print("Error: Key required (--key or --key-file).", file=sys.stderr)
+                return False
+
+            result = manager.hmac_data(data, key, args.algo)
             print(result)
             return True
 

--- a/shared/tui_crypto.py
+++ b/shared/tui_crypto.py
@@ -29,6 +29,21 @@ class CryptoLabTab(Container):
                         yield Label("[bold]Hash Output[/bold]")
                         yield TextArea(id="crypto-hash-output", read_only=True)
 
+                # HMAC
+                with TabPane("HMAC"):
+                    with Vertical(classes="stat-box"):
+                        yield Label("Input (Text):")
+                        yield TextArea(id="crypto-hmac-input")
+                        yield Label("Key:")
+                        yield Input(id="crypto-hmac-key")
+                        yield Label("Algorithm:")
+                        yield Select.from_values(["md5", "sha1", "sha256", "sha512"], id="crypto-hmac-algo", value="sha256")
+                        yield Button("Generate HMAC", id="btn-crypto-hmac", variant="primary")
+
+                    with Vertical(classes="stat-box"):
+                        yield Label("[bold]HMAC Output[/bold]")
+                        yield TextArea(id="crypto-hmac-output", read_only=True)
+
                 # Encrypt
                 with TabPane("Encrypt"):
                     with Horizontal(classes="stat-box"):
@@ -110,6 +125,8 @@ class CryptoLabTab(Container):
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "btn-crypto-hash":
             self.do_hash()
+        elif event.button.id == "btn-crypto-hmac":
+            self.do_hmac()
         elif event.button.id == "btn-crypto-gen-key":
             self.do_gen_key()
         elif event.button.id == "btn-crypto-encrypt":
@@ -142,6 +159,23 @@ class CryptoLabTab(Container):
             res = self.manager.hash_data(text, str(algo))
             out.text = res
             self.notify("Hash calculated.")
+        except Exception as e:
+            self.notify(f"Error: {e}", severity="error")
+
+    def do_hmac(self) -> None:
+        text = self.query_one("#crypto-hmac-input", TextArea).text
+        key = self.query_one("#crypto-hmac-key", Input).value
+        algo = self.query_one("#crypto-hmac-algo", Select).value or "sha256"
+        out = self.query_one("#crypto-hmac-output", TextArea)
+
+        if not text or not key:
+            self.notify("Input and Key required.", severity="error")
+            return
+
+        try:
+            res = self.manager.hmac_data(text, key, str(algo))
+            out.text = res
+            self.notify("HMAC calculated.")
         except Exception as e:
             self.notify(f"Error: {e}", severity="error")
 

--- a/tests/test_crypto_lab.py
+++ b/tests/test_crypto_lab.py
@@ -22,6 +22,15 @@ def test_hash_data(crypto_manager):
     # Test Bytes
     assert crypto_manager.hash_data(b"hello world", "sha256") == expected
 
+def test_hmac_data(crypto_manager):
+    input_data = "hello world"
+    key = "secret"
+    expected = "734cc62f32841568f45715aeb9f4d7891324e6d948e4c6c60c0621cdac48623a"
+    assert crypto_manager.hmac_data(input_data, key, "sha256") == expected
+
+    # Test Bytes
+    assert crypto_manager.hmac_data(b"hello world", b"secret", "sha256") == expected
+
 def test_generate_key(crypto_manager):
     key = crypto_manager.generate_key()
     assert isinstance(key, bytes)
@@ -70,6 +79,19 @@ def test_cli_hash(capsys):
     run_crypto_lab_logic(args)
     captured = capsys.readouterr()
     assert "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08" in captured.out
+
+def test_cli_hmac(capsys):
+    args = MagicMock()
+    args.action = "hmac"
+    args.text = "hello world"
+    args.file = None
+    args.key = "secret"
+    args.key_file = None
+    args.algo = "sha256"
+
+    run_crypto_lab_logic(args)
+    captured = capsys.readouterr()
+    assert "734cc62f32841568f45715aeb9f4d7891324e6d948e4c6c60c0621cdac48623a" in captured.out
 
 def test_cli_gen_key(capsys):
     args = MagicMock()


### PR DESCRIPTION
This PR adds an `hmac` action to the `crypto-lab` functionality, allowing users to securely generate Hash-based Message Authentication Codes via the CLI and the Textual UI.

**Features added:**
*   **CLI:** `main.py crypto-lab hmac --text "data" --key "secret"`
*   **TUI:** A dedicated "HMAC" tab within the "Crypto Lab" UI panel.
*   **Core:** `CryptoLabManager.hmac_data` leveraging the standard library `hmac` module.

**Testing:**
*   Added `test_hmac_data` to verify the internal manager behavior.
*   Added `test_cli_hmac` to verify argument parsing and output.

This addresses a critical cryptography toolset gap by supporting one of the most common authentication primitive derivations.

---
*PR created automatically by Jules for task [14520602038169202423](https://jules.google.com/task/14520602038169202423) started by @process-failed-successfully*