### PR TITLE
feat(jwt-lab): Add `crack` subcommand to perform wordlist dictionary attacks on HMAC JWT tokens

### DIFF
--- a/main.py
+++ b/main.py
@@ -14393,6 +14393,11 @@ def parse_args(argv=None):
     parser_jwt_verify.add_argument("--secret", required=True, help="Secret key.")
     parser_jwt_verify.add_argument("-v", "--verbose", action="store_true", help="Show decoded content if valid.")
 
+    # jwt-lab crack
+    parser_jwt_crack = jwt_subparsers.add_parser("crack", help="Crack a JWT token's HMAC secret using a wordlist.")
+    parser_jwt_crack.add_argument("token", help="The JWT token.")
+    parser_jwt_crack.add_argument("--wordlist", required=True, help="Path to the dictionary/wordlist file.")
+
     # jwt-lab tui
     parser_jwt_tui = jwt_subparsers.add_parser("tui", help="Launch JWT Lab TUI.")
 

--- a/shared/jwt_lab.py
+++ b/shared/jwt_lab.py
@@ -156,6 +156,50 @@ class JWTManager:
 
         return decoded
 
+    @staticmethod
+    def crack_token(token: str, wordlist_path: str) -> str | None:
+        """
+        Attempts to crack the secret of an HMAC JWT token using a wordlist.
+        """
+        parts = token.split('.')
+        if len(parts) != 3:
+            raise ValueError("Invalid token format (expected 3 parts)")
+
+        header_b64, payload_b64, signature_b64 = parts
+
+        try:
+            header_json = JWTManager.base64url_decode(header_b64)
+            header = json.loads(header_json)
+        except Exception as e:
+            raise ValueError(f"Failed to decode token header: {e}")
+
+        algo = header.get("alg")
+        if not algo or not algo.startswith("HS"):
+            raise ValueError(f"Cracking is only supported for HMAC algorithms (HS256, HS384, HS512). Token uses: {algo}")
+
+        if algo not in JWTManager.ALGORITHMS:
+            raise ValueError(f"Unsupported algorithm: {algo}")
+
+        hash_func = JWTManager.ALGORITHMS[algo]
+        signing_input = f"{header_b64}.{payload_b64}".encode('utf-8')
+
+        try:
+            with open(wordlist_path, 'r', encoding='utf-8', errors='ignore') as f:
+                for line in f:
+                    secret = line.strip()
+                    if not secret:
+                        continue
+
+                    expected_signature = hmac.new(secret.encode('utf-8'), signing_input, hash_func).digest()
+                    expected_signature_b64 = JWTManager.base64url_encode(expected_signature)
+
+                    if hmac.compare_digest(signature_b64, expected_signature_b64):
+                        return secret
+        except FileNotFoundError:
+            raise ValueError(f"Wordlist file not found: {wordlist_path}")
+
+        return None
+
 def run_jwt_lab_logic(args) -> bool:
     manager = JWTManager()
 
@@ -186,6 +230,24 @@ def run_jwt_lab_logic(args) -> bool:
                 return True
             except ValueError as e:
                 print(f"❌ Verification Failed: {e}", file=sys.stderr)
+                return False
+
+        elif args.action == "crack":
+            print(f"Attempting to crack token using wordlist: {args.wordlist}...")
+            start_time = time.time()
+            try:
+                secret = manager.crack_token(args.token, args.wordlist)
+                elapsed = time.time() - start_time
+                if secret:
+                    print(f"✅ CRACKED! Secret found: {secret}")
+                    print(f"Time taken: {elapsed:.2f}s")
+                    return True
+                else:
+                    print(f"❌ Failed to crack token. Secret not in wordlist.")
+                    print(f"Time taken: {elapsed:.2f}s")
+                    return False
+            except ValueError as e:
+                print(f"❌ Error: {e}", file=sys.stderr)
                 return False
 
     except Exception as e:

--- a/tests/test_jwt_lab.py
+++ b/tests/test_jwt_lab.py
@@ -132,5 +132,69 @@ class TestJWTManager(unittest.TestCase):
 
         self.assertEqual(str(context.exception), "Key confusion vulnerability detected: token specifies HMAC but an asymmetric key was provided.")
 
+    def test_crack_token_success(self):
+        # Create a temporary wordlist
+        import tempfile
+        import os
+
+        token = self.manager.sign_token(self.payload, self.secret, "HS256")
+
+        fd, path = tempfile.mkstemp()
+        with os.fdopen(fd, 'w') as f:
+            f.write("wrongsecret1\n")
+            f.write("wrongsecret2\n")
+            f.write(self.secret + "\n")
+            f.write("wrongsecret3\n")
+
+        try:
+            cracked_secret = self.manager.crack_token(token, path)
+            self.assertEqual(cracked_secret, self.secret)
+        finally:
+            os.remove(path)
+
+    def test_crack_token_failure(self):
+        import tempfile
+        import os
+
+        token = self.manager.sign_token(self.payload, self.secret, "HS256")
+
+        fd, path = tempfile.mkstemp()
+        with os.fdopen(fd, 'w') as f:
+            f.write("wrongsecret1\n")
+            f.write("wrongsecret2\n")
+
+        try:
+            cracked_secret = self.manager.crack_token(token, path)
+            self.assertIsNone(cracked_secret)
+        finally:
+            os.remove(path)
+
+    def test_crack_token_unsupported_algo(self):
+        import tempfile
+        import os
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.hazmat.primitives import serialization
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        private_pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption()
+        ).decode('utf-8')
+
+        token = self.manager.sign_token(self.payload, private_pem, "RS256")
+
+        fd, path = tempfile.mkstemp()
+        with os.fdopen(fd, 'w') as f:
+            f.write("dummy\n")
+
+        try:
+            with self.assertRaises(ValueError) as context:
+                self.manager.crack_token(token, path)
+            self.assertIn("only supported for HMAC algorithms", str(context.exception))
+        finally:
+            os.remove(path)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR introduces a bold, high-value feature to the `jwt-lab` toolkit.

The new `crack` subcommand enables users to perform dictionary-based cracking of JWT tokens that utilize HMAC algorithms (e.g. HS256, HS384, HS512). 
It takes a JWT token and a path to a wordlist (dictionary) file, efficiently iterating through the list line-by-line while computing and comparing HMAC digests securely utilizing `hmac.compare_digest` to thwart timing attacks.

It includes:
-   A new `crack_token(token, wordlist_path)` method in `JWTManager`.
-   CLI routing and timing information in `run_jwt_lab_logic` allowing `jwt-lab crack <token> --wordlist <path>`.
-   Integration into the `main.py` argparse.
-   Comprehensive unit testing in `test_jwt_lab.py`, including success, failure, and unsupported algorithm testing using isolated temporary file usage.

---
*PR created automatically by Jules for task [16798875200648674620](https://jules.google.com/task/16798875200648674620) started by @process-failed-successfully*