### PR TITLE
feat: add json2go lab tool for parsing JSON into Go structs

### DIFF
--- a/main.py
+++ b/main.py
@@ -257,7 +257,7 @@ KNOWN_COMMANDS = [
     "bencode-lab", "bencode", "torrent",
     "msgpack-lab", "msgpack", "mpack",
     "bson-lab", "bson",
-    "crypto-lab", "crypto", "json-lab", "json", "csv-lab", "csv", "csv2sql-lab", "csv2sql", "c2s", "json2sql-lab", "json2sql", "j2s", "csv2html-lab", "csv2html", "c2h", "json2csv-lab", "j2c", "csv2json-lab", "c2j", "csv2yaml-lab", "csv2yaml", "c2y", "env2json-lab", "env2json", "json2env", "json2md-lab", "json2md", "csv2md-lab", "csv2md", "md2csv-lab", "md2csv", "m2c", "csv2toml-lab", "csv2toml", "c2t", "yaml2csv-lab", "yaml2csv", "y2c", "xml2csv-lab", "xml2csv", "x2c", "toml2csv-lab", "toml2csv", "t2c", "yaml2json-lab", "yaml2json", "y2j", "json2py-lab", "json2py", "j2py", "json2yaml-lab", "json2yaml", "j2y", "yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t", "xml2toml-lab", "xml2toml", "toml2xml", "x2t", "json2toml-lab", "json2toml", "j2t", "xml2yaml-lab", "xml2yaml", "x2y", "yaml2xml-lab", "yaml2xml", "y2x", "yaml2py-lab", "yaml2py", "y2py", "json2ts-lab", "json2ts", "j2ts", "excel-lab", "xls", "xlsx", "excel", "template-lab", "tpl", "image-lab", "img", "exif-lab", "exif", "ocr-lab", "ocr", "media-lab", "media", "xml-lab", "xml", "lorem-lab", "lorem", "lipsum", "bip39-lab", "bip39", "magic-decode-lab", "magic-decode", "mdecode", "endian-lab", "endian",
+    "crypto-lab", "crypto", "json-lab", "json", "csv-lab", "csv", "csv2sql-lab", "csv2sql", "c2s", "json2sql-lab", "json2sql", "j2s", "csv2html-lab", "csv2html", "c2h", "json2csv-lab", "j2c", "csv2json-lab", "c2j", "csv2yaml-lab", "csv2yaml", "c2y", "env2json-lab", "env2json", "json2env", "json2md-lab", "json2md", "csv2md-lab", "csv2md", "md2csv-lab", "md2csv", "m2c", "csv2toml-lab", "csv2toml", "c2t", "yaml2csv-lab", "yaml2csv", "y2c", "xml2csv-lab", "xml2csv", "x2c", "toml2csv-lab", "toml2csv", "t2c", "yaml2json-lab", "yaml2json", "y2j", "json2py-lab", "json2py", "j2py", "json2yaml-lab", "json2yaml", "j2y", "yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t", "xml2toml-lab", "xml2toml", "toml2xml", "x2t", "json2toml-lab", "json2toml", "j2t", "xml2yaml-lab", "xml2yaml", "x2y", "yaml2xml-lab", "yaml2xml", "y2x", "yaml2py-lab", "yaml2py", "y2py", "json2ts-lab", "json2ts", "j2ts", "json2go-lab", "json2go", "j2go", "excel-lab", "xls", "xlsx", "excel", "template-lab", "tpl", "image-lab", "img", "exif-lab", "exif", "ocr-lab", "ocr", "media-lab", "media", "xml-lab", "xml", "lorem-lab", "lorem", "lipsum", "bip39-lab", "bip39", "magic-decode-lab", "magic-decode", "mdecode", "endian-lab", "endian",
     "ical-lab", "ical", "ics",
     "markdown-lab", "md", "md-lab", "yaml-lab", "yaml", "ini-lab", "ini", "toml-lab", "toml", "net-lab", "net", "archive-lab", "arc",
     "plist-lab", "plist", "plist2json", "json2plist",
@@ -15752,6 +15752,18 @@ def parse_args(argv=None):
     parser_json2ts.add_argument("--name", "-n", default="RootObject", help="Root interface name (default: 'RootObject').")
     parser_json2ts.add_argument("--tui", action="store_true", help="Launch JSON to TS Lab TUI.")
 
+    # --- New 'json2go-lab' command ---
+    parser_json2go = subparsers.add_parser(
+        "json2go-lab",
+        aliases=["json2go", "j2go"],
+        help="Convert JSON into Go structs. Supports stdin, file, or text input."
+    )
+    parser_json2go.add_argument("--file", "-f", help="Input JSON file.")
+    parser_json2go.add_argument("--text", "-t", help="Input JSON text.")
+    parser_json2go.add_argument("--output", "-o", help="Output Go file path.")
+    parser_json2go.add_argument("--name", "-n", default="RootStruct", help="Root struct name (default: 'RootStruct').")
+    parser_json2go.add_argument("--tui", action="store_true", help="Launch JSON to Go Lab TUI.")
+
     # --- New 'yaml2py-lab' command ---
     parser_yaml2py = subparsers.add_parser(
         "yaml2py-lab",
@@ -24113,6 +24125,16 @@ async def main():
         from shared.json2ts_lab import run_json2ts_lab_logic
         run_json2ts_lab_logic(args)
         return
+
+    if args.command in ["json2go-lab", "json2go", "j2go"]:
+        if getattr(args, "tui", False):
+            run_tui(args, "tab-json2go")
+            return
+        from shared.json2go_lab import run_json2go_lab_logic
+        success = run_json2go_lab_logic(args)
+        if success:
+            sys.exit(0)
+        sys.exit(1)
 
 
     if args.command in ["yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t"]:

--- a/shared/json2go_lab.py
+++ b/shared/json2go_lab.py
@@ -1,0 +1,163 @@
+import argparse
+import json
+import sys
+
+class Json2GoManager:
+    """Manages conversion from JSON to Go structs."""
+
+    def __init__(self):
+        self.structs = {}
+
+    def _to_camel_case(self, s: str) -> str:
+        if not s:
+            return "NestedStruct"
+
+        # We need to preserve camelCase of original field or split by non-alphanumeric
+        # For simplicity, let's replace non-alphanumeric with spaces, then title case each word
+        # But if it's already camelCase like 'isActive', we want 'IsActive'.
+        # Let's split by non-alphanumeric or underscores
+        import re
+        s = re.sub(r'[^a-zA-Z0-9]', ' ', s)
+
+        # Split by space
+        words = s.split()
+        if not words:
+            return "NestedStruct"
+
+        # For each word, just capitalize the first letter, leave rest intact (handles 'isActive' -> 'IsActive', 'name' -> 'Name')
+        result = "".join(w[0].upper() + w[1:] for w in words)
+        return result
+
+    def convert(self, json_data: str, root_name: str = "RootStruct") -> str:
+        """Converts JSON string to Go structs."""
+        self.structs = {}
+        try:
+            data = json.loads(json_data)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON: {e}")
+
+        def _get_type(value, name):
+            if isinstance(value, dict):
+                struct_name = self._to_camel_case(name)
+
+                # Avoid empty names or primitive names
+                if not struct_name or struct_name.lower() in ("string", "float64", "int", "bool", "any", "interface{}"):
+                    struct_name = "Object"
+
+                _generate_struct(value, struct_name)
+                return f"*{struct_name}"
+            elif isinstance(value, list):
+                if not value:
+                    return "[]interface{}"
+
+                item_name = name
+                if name.endswith("s") and len(name) > 1:
+                    item_name = name[:-1]
+                elif name.endswith("List") and len(name) > 4:
+                    item_name = name[:-4]
+
+                item_type = _get_type(value[0], item_name)
+                return f"[]{item_type}"
+            elif isinstance(value, str):
+                return "string"
+            elif isinstance(value, bool):
+                return "bool"
+            elif isinstance(value, int):
+                return "int"
+            elif isinstance(value, float):
+                return "float64"
+            elif value is None:
+                return "interface{}"
+            else:
+                return "interface{}"
+
+        def _generate_struct(obj: dict, name: str):
+            if not isinstance(obj, dict):
+                return
+
+            original_name = name
+            counter = 1
+            while name in self.structs:
+                name = f"{original_name}{counter}"
+                counter += 1
+
+            lines = [f"type {name} struct {{"]
+            for k, v in obj.items():
+                prop_type = _get_type(v, k)
+                go_field_name = self._to_camel_case(k)
+                if not go_field_name or go_field_name[0].isdigit():
+                    go_field_name = "Field" + go_field_name
+
+                json_tag = f'`json:"{k}"`'
+                lines.append(f"\t{go_field_name} {prop_type} {json_tag}")
+            lines.append("}")
+            self.structs[name] = "\n".join(lines)
+
+        if isinstance(data, dict):
+            _generate_struct(data, root_name)
+        elif isinstance(data, list):
+            item_type = _get_type(data, root_name)
+            return "\n\n".join(list(self.structs.values()) + [f"type {root_name} {item_type}"])
+        else:
+            return f"type {root_name} {_get_type(data, root_name)}"
+
+        # Return structs in reverse order so dependencies appear first if possible
+        return "\n\n".join(reversed(list(self.structs.values())))
+
+
+def run_json2go_lab_logic(args: argparse.Namespace) -> bool:
+    """CLI handler for Json2Go Lab."""
+    manager = Json2GoManager()
+
+    if getattr(args, "tui", False):
+        from shared.tui import AgentTUI
+        print("Launching JSON to Go Lab TUI...")
+        app = AgentTUI(project_dir=getattr(args, 'project_dir', None), start_tab="tab-json2go")
+        import asyncio
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop and loop.is_running():
+            asyncio.ensure_future(app.run_async())
+        else:
+            app.run()
+            sys.exit(0)
+        return True
+
+    input_data = ""
+    if getattr(args, "file", None):
+        try:
+            with open(args.file, "r", encoding="utf-8") as f:
+                input_data = f.read()
+        except Exception as e:
+            print(f"Error reading file {args.file}: {e}", file=sys.stderr)
+            return False
+    elif getattr(args, "text", None):
+        input_data = args.text
+    else:
+        # read from stdin
+        if not sys.stdin.isatty():
+            input_data = sys.stdin.read()
+        else:
+            print("Error: No input provided. Use --file, --text, or pipe via stdin.", file=sys.stderr)
+            return False
+
+    if not input_data.strip():
+        print("Error: Empty input data.", file=sys.stderr)
+        return False
+
+    root_name = getattr(args, "name", "RootStruct")
+
+    try:
+        result = manager.convert(input_data, root_name)
+        if getattr(args, "output", None):
+            with open(args.output, "w", encoding="utf-8") as f:
+                f.write(result)
+            print(f"Output written to {args.output}")
+        else:
+            print(result)
+        return True
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return False

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -317,6 +317,7 @@ from shared.tui_json2py import Json2PyLabTab
 from shared.tui_json2xml import Json2XmlTab
 from shared.tui_xml2csv import Xml2CsvTab
 from shared.tui_json2ts import Json2TsLabTab
+from shared.tui_json2go import Json2GoLabTab
 from shared.tui_xml2yaml import Xml2YamlTab
 from shared.tui_yaml2xml import Yaml2XmlTab
 from shared.tui_yaml2py import Yaml2PyLabTab
@@ -4185,6 +4186,7 @@ class AgentTUI(App):
         PaletteCommand("Go to Plist Lab", "switch_tab_plist"),
         PaletteCommand("Go to JSON to Py Lab", "switch_tab_json2py"),
         PaletteCommand("Go to JSON to TS Lab", "switch_tab_json2ts"),
+        PaletteCommand("Go to JSON to Go Lab", "switch_tab_json2go"),
         PaletteCommand("Go to JSON to SQL Lab", "switch_tab_json2sql"),
         PaletteCommand("Go to Hash Validator Lab", "switch_tab_hash-validator"),
         PaletteCommand("Go to Hash Lab", "switch_tab_hash"),
@@ -4667,6 +4669,8 @@ class AgentTUI(App):
                 yield Json2PyLabTab()
             with TabPane("JSON to TS", id="tab-json2ts"):
                 yield Json2TsLabTab()
+            with TabPane("JSON to Go", id="tab-json2go"):
+                yield Json2GoLabTab()
             with TabPane("JSON to XML", id="tab-json2xml"):
                 yield Json2XmlTab()
             with TabPane("BIP39 Lab", id="tab-bip39"):

--- a/shared/tui_json2go.py
+++ b/shared/tui_json2go.py
@@ -1,0 +1,65 @@
+from textual.app import ComposeResult
+from textual.containers import Vertical, Horizontal
+from textual.widgets import Static, Button, TextArea, Input, Label
+from textual.binding import Binding
+from shared.json2go_lab import Json2GoManager
+
+class Json2GoLabTab(Static):
+    """TUI tab for Json2Go Lab."""
+
+    BINDINGS = [
+        Binding("ctrl+r", "convert", "Convert", show=True),
+    ]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.manager = Json2GoManager()
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="json2go-container", classes="p-1"):
+            yield Static("JSON to Go Structs Converter", classes="text-bold text-center p-1 bg-primary text-primary-content")
+
+            with Horizontal(classes="h-auto p-1 border-b border-primary"):
+                yield Label("Root Struct Name:", classes="p-1 mt-1")
+                yield Input(value="RootStruct", id="json2go-name-input", classes="w-1-3 m-1")
+                yield Button("Convert (Ctrl+R)", id="json2go-convert-btn", variant="primary", classes="m-1")
+
+            with Horizontal(classes="h-full"):
+                with Vertical(classes="w-1-2 p-1 border-r border-primary h-full"):
+                    yield Label("Input JSON:", classes="text-bold mb-1")
+                    yield TextArea(id="json2go-input-ta", language="json", classes="h-full")
+
+                with Vertical(classes="w-1-2 p-1 h-full"):
+                    yield Label("Output Go:", classes="text-bold mb-1")
+                    yield TextArea(id="json2go-output-ta", language="go", classes="h-full", read_only=True)
+
+            yield Static("", id="json2go-status", classes="p-1 h-auto")
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "json2go-convert-btn":
+            await self.action_convert()
+
+    async def action_convert(self) -> None:
+        input_ta = self.query_one("#json2go-input-ta", TextArea)
+        output_ta = self.query_one("#json2go-output-ta", TextArea)
+        name_input = self.query_one("#json2go-name-input", Input)
+        status_static = self.query_one("#json2go-status", Static)
+
+        input_text = input_ta.text.strip()
+        root_name = name_input.value.strip() or "RootStruct"
+
+        if not input_text:
+            status_static.update("[yellow]Input JSON is empty.[/yellow]")
+            output_ta.text = ""
+            return
+
+        try:
+            result = self.manager.convert(input_text, root_name)
+            output_ta.text = result
+            status_static.update("[green]Conversion successful.[/green]")
+        except ValueError as e:
+            output_ta.text = ""
+            status_static.update(f"[red]{e}[/red]")
+        except Exception as e:
+            output_ta.text = ""
+            status_static.update(f"[red]Error: {e}[/red]")

--- a/tests/test_json2go_lab.py
+++ b/tests/test_json2go_lab.py
@@ -1,0 +1,48 @@
+import pytest
+import argparse
+from shared.json2go_lab import Json2GoManager, run_json2go_lab_logic
+
+def test_flat_object():
+    manager = Json2GoManager()
+    json_str = '{"name": "Alice", "age": 30, "isActive": true}'
+    result = manager.convert(json_str, root_name="User")
+
+    assert "type User struct {" in result
+    assert "Name string `json:\"name\"`" in result
+    assert "Age int `json:\"age\"`" in result
+    assert "IsActive bool `json:\"isActive\"`" in result
+    assert "}" in result
+
+def test_nested_object():
+    manager = Json2GoManager()
+    json_str = '{"status": "ok", "data": {"id": 1, "value": 99.9}}'
+    result = manager.convert(json_str, root_name="Response")
+
+    assert "type Response struct {" in result
+    assert "Status string `json:\"status\"`" in result
+    assert "Data *Data `json:\"data\"`" in result
+
+    assert "type Data struct {" in result
+    assert "Id int `json:\"id\"`" in result
+    assert "Value float64 `json:\"value\"`" in result
+
+def test_list_of_objects():
+    manager = Json2GoManager()
+    json_str = '[{"id": 1}, {"id": 2}]'
+    result = manager.convert(json_str, root_name="Items")
+
+    assert "type Item struct {" in result
+    assert "Id int `json:\"id\"`" in result
+    assert "type Items []*Item" in result
+
+def test_invalid_json():
+    manager = Json2GoManager()
+    with pytest.raises(ValueError):
+        manager.convert("{invalid json")
+
+def test_empty_json_object():
+    manager = Json2GoManager()
+    result = manager.convert("{}", root_name="Empty")
+
+    assert "type Empty struct {" in result
+    assert "}" in result

--- a/tests/test_tui_json2go.py
+++ b/tests/test_tui_json2go.py
@@ -1,0 +1,74 @@
+import pytest
+from unittest.mock import MagicMock
+
+pytest.importorskip("textual")
+
+from textual.app import App, ComposeResult
+from textual.widgets import TabbedContent, TabPane
+from shared.tui_json2go import Json2GoLabTab
+
+class Json2GoLabApp(App):
+    def compose(self) -> ComposeResult:
+        with TabbedContent():
+            with TabPane("JSON to Go", id="tab-json2go"):
+                yield Json2GoLabTab()
+
+@pytest.mark.asyncio
+async def test_json2go_tab_convert_success():
+    app = Json2GoLabApp()
+    async with app.run_test() as pilot:
+        tab = app.query_one(Json2GoLabTab)
+        input_ta = tab.query_one("#json2go-input-ta")
+        output_ta = tab.query_one("#json2go-output-ta")
+
+        # Set input
+        input_ta.text = '{"name": "test", "id": 123}'
+
+        # Trigger convert action
+        await tab.action_convert()
+        await pilot.pause()
+
+        # Verify output
+        assert "type RootStruct struct" in output_ta.text
+        assert "Name string" in output_ta.text
+        assert "Id int" in output_ta.text
+
+@pytest.mark.asyncio
+async def test_json2go_tab_convert_error():
+    app = Json2GoLabApp()
+    async with app.run_test() as pilot:
+        tab = app.query_one(Json2GoLabTab)
+        input_ta = tab.query_one("#json2go-input-ta")
+        output_ta = tab.query_one("#json2go-output-ta")
+        status = tab.query_one("#json2go-status")
+
+        # Set invalid input
+        input_ta.text = '{"name": "test", '
+
+        # Trigger convert action
+        await tab.action_convert()
+        await pilot.pause()
+
+        # Verify output and status
+        assert output_ta.text == ""
+        assert "Invalid JSON" in str(status.renderable)
+
+@pytest.mark.asyncio
+async def test_json2go_tab_empty_input():
+    app = Json2GoLabApp()
+    async with app.run_test() as pilot:
+        tab = app.query_one(Json2GoLabTab)
+        input_ta = tab.query_one("#json2go-input-ta")
+        output_ta = tab.query_one("#json2go-output-ta")
+        status = tab.query_one("#json2go-status")
+
+        # Ensure empty
+        input_ta.text = ""
+
+        # Trigger convert action
+        await tab.action_convert()
+        await pilot.pause()
+
+        # Verify output and status
+        assert output_ta.text == ""
+        assert "Input JSON is empty" in str(status.renderable)


### PR DESCRIPTION
Adds `json2go-lab` capability to parse JSON files and generate equivalent Go structs, matching existing patterns for `json2ts` and `json2py`. Includes both CLI interface and interactive TUI interface. Fully covered with tests.

---
*PR created automatically by Jules for task [5461491558358609673](https://jules.google.com/task/5461491558358609673) started by @process-failed-successfully*