### PR TITLE
feat: Add JSON Flatten/Unflatten Lab

### DIFF
--- a/.agent_history
+++ b/.agent_history
@@ -11,3 +11,4 @@ gemini_agent_app_0c4237f1
 gemini_agent_app_0c4237f1
 gemini_agent_app_0c4237f1
 gemini_agent_app_0c4237f1
+gemini_agent_app_0c4237f1

--- a/main.py
+++ b/main.py
@@ -20083,6 +20083,24 @@ Examples:
     isbn_convert = isbn_subparsers.add_parser("convert", help="Convert an ISBN-10 to ISBN-13.")
     isbn_convert.add_argument("isbn", help="The ISBN-10 string to convert.")
 
+    parser_flatten = subparsers.add_parser(
+        "json-flatten-lab", aliases=["flatten", "unflatten"], help="Flatten and unflatten JSON structures."
+    )
+    flatten_subparsers = parser_flatten.add_subparsers(dest="action", help="Action to perform")
+    flatten_subparsers.add_parser("tui", help="Launch the interactive JSON Flatten Lab TUI.")
+
+    flatten_action = flatten_subparsers.add_parser("flatten", help="Flatten nested JSON.")
+    flatten_action.add_argument("--text", help="JSON string to flatten.")
+    flatten_action.add_argument("--file", help="JSON file to flatten.")
+    flatten_action.add_argument("--output", help="Output file path.")
+    flatten_action.add_argument("--separator", default=".", help="Separator for flattened keys (default: .).")
+
+    unflatten_action = flatten_subparsers.add_parser("unflatten", help="Unflatten flat JSON.")
+    unflatten_action.add_argument("--text", help="Flat JSON string to unflatten.")
+    unflatten_action.add_argument("--file", help="Flat JSON file to unflatten.")
+    unflatten_action.add_argument("--output", help="Output file path.")
+    unflatten_action.add_argument("--separator", default=".", help="Separator for flattened keys (default: .).")
+
     parser_zip = subparsers.add_parser(
         "zip-lab", aliases=["zip"], help="Utilities for creating and extracting zip archives."
     )
@@ -24075,6 +24093,13 @@ async def main():
     if args.command in ["time-lab", "time"]:
         run_time_lab(args)
         return
+
+    elif args.command in ["json-flatten-lab", "flatten", "unflatten"]:
+        if args.action == "tui":
+            run_tui(args, "tab-flatten")
+        else:
+            from shared.flatten_lab import run_flatten_lab_logic
+            run_flatten_lab_logic(args)
 
     if args.command in ["date-lab", "date"]:
         if args.action == "tui":

--- a/shared/flatten_lab.py
+++ b/shared/flatten_lab.py
@@ -1,0 +1,122 @@
+import json
+import sys
+from typing import Any, Dict, List, Union
+
+class FlattenManager:
+    """Manages JSON flattening and unflattening operations."""
+
+    def __init__(self, separator: str = "."):
+        self.separator = separator
+
+    def flatten(self, data: Union[Dict[str, Any], List[Any]], parent_key: str = '') -> Dict[str, Any]:
+        """Flattens a nested dictionary or list."""
+        items: List[tuple] = []
+        if isinstance(data, dict):
+            for k, v in data.items():
+                new_key = f"{parent_key}{self.separator}{k}" if parent_key else k
+                if isinstance(v, (dict, list)) and v:  # don't recurse on empty dict/list
+                    items.extend(self.flatten(v, new_key).items())
+                else:
+                    items.append((new_key, v))
+        elif isinstance(data, list):
+            for i, v in enumerate(data):
+                new_key = f"{parent_key}{self.separator}{i}" if parent_key else str(i)
+                if isinstance(v, (dict, list)) and v:
+                    items.extend(self.flatten(v, new_key).items())
+                else:
+                    items.append((new_key, v))
+        else:
+            if parent_key:
+                items.append((parent_key, data))
+            else:
+                return data
+
+        return dict(items)
+
+    def unflatten(self, flat_data: Dict[str, Any]) -> Union[Dict[str, Any], List[Any]]:
+        """Unflattens a flat dictionary with separated keys into a nested structure."""
+        if not isinstance(flat_data, dict):
+            return flat_data
+
+        unflattened: Dict[str, Any] = {}
+
+        for key, value in flat_data.items():
+            parts = key.split(self.separator)
+            current = unflattened
+            for i, part in enumerate(parts):
+                if i == len(parts) - 1:
+                    current[part] = value
+                else:
+                    if part not in current:
+                        current[part] = {}
+                    current = current[part]
+
+        return self._convert_numeric_keys_to_lists(unflattened)
+
+    def _convert_numeric_keys_to_lists(self, data: Any) -> Any:
+        """Recursively converts dicts with purely sequential numeric keys starting at 0 into lists."""
+        if isinstance(data, dict):
+            # Check if all keys are sequential integers starting from 0
+            if data and all(k.isdigit() for k in data.keys()):
+                keys = [int(k) for k in data.keys()]
+                if sorted(keys) == list(range(len(keys))):
+                    return [self._convert_numeric_keys_to_lists(data[str(i)]) for i in range(len(keys))]
+
+            # If not a purely sequential numeric dictionary, just recurse
+            return {k: self._convert_numeric_keys_to_lists(v) for k, v in data.items()}
+        elif isinstance(data, list):
+            return [self._convert_numeric_keys_to_lists(item) for item in data]
+        else:
+            return data
+
+
+def run_flatten_lab_logic(args) -> bool:
+    """CLI logic for the Flatten Lab."""
+    manager = FlattenManager(separator=args.separator)
+
+    input_text = None
+    if args.text:
+        input_text = args.text
+    elif args.file:
+        try:
+            with open(args.file, "r") as f:
+                input_text = f.read()
+        except Exception as e:
+            print(f"❌ Error reading file: {e}", file=sys.stderr)
+            return False
+    elif not sys.stdin.isatty():
+        input_text = sys.stdin.read().strip()
+
+    if not input_text:
+        print("❌ Error: No input data provided. Use --text, --file, or stdin.", file=sys.stderr)
+        return False
+
+    try:
+        data = json.loads(input_text)
+    except json.JSONDecodeError as e:
+        print(f"❌ Error parsing JSON: {e}", file=sys.stderr)
+        return False
+
+    if args.action == "flatten":
+        result = manager.flatten(data)
+    elif args.action == "unflatten":
+        if not isinstance(data, dict):
+            print("❌ Error: Input to unflatten must be a JSON object (dictionary).", file=sys.stderr)
+            return False
+        result = manager.unflatten(data)
+    else:
+        print(f"❌ Error: Unknown action '{args.action}'.", file=sys.stderr)
+        return False
+
+    try:
+        output_str = json.dumps(result, indent=2)
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(output_str)
+            print(f"✅ Saved to {args.output}")
+        else:
+            print(output_str)
+        return True
+    except Exception as e:
+        print(f"❌ Error formatting or writing output: {e}", file=sys.stderr)
+        return False

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -321,6 +321,7 @@ from shared.tui_xml2csv import Xml2CsvTab
 from shared.tui_json2ts import Json2TsLabTab
 from shared.tui_json2go import Json2GoLabTab
 from shared.tui_xml2yaml import Xml2YamlTab
+from shared.tui_flatten import FlattenLabTab
 from shared.tui_yaml2xml import Yaml2XmlTab
 from shared.tui_json2java import Json2JavaTab
 from shared.tui_yaml2py import Yaml2PyLabTab
@@ -4273,6 +4274,8 @@ class AgentTUI(App):
     def compose(self) -> ComposeResult:
         yield Header()
         with TabbedContent(id="main-tabs", initial=self.start_tab):
+            if self.start_tab == "tab-flatten":
+                yield FlattenLabTab()
             with TabPane("Static Lab", id="tab-static"):
                 yield StaticLabTab(project_dir=self.project_dir)
             with TabPane("Dashboard", id="tab-dashboard"):

--- a/shared/tui_flatten.py
+++ b/shared/tui_flatten.py
@@ -1,0 +1,70 @@
+import json
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal, Vertical
+from textual.widgets import Button, TextArea, Static, TabPane
+from shared.flatten_lab import FlattenManager
+
+class FlattenLabTab(TabPane):
+    """Interactive TUI for JSON Flattening and Unflattening."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__("JSON Flatten Lab", id="tab-flatten", *args, **kwargs)
+        self.manager = FlattenManager()
+
+    def compose(self) -> ComposeResult:
+        with Horizontal():
+            with Vertical(classes="column"):
+                yield Static("Nested JSON:", classes="header-label")
+                yield TextArea(
+                    "{\n  \"user\": {\n    \"name\": \"Alice\",\n    \"roles\": [\"admin\", \"user\"]\n  }\n}",
+                    id="nested-json",
+                    language="json",
+                )
+
+            with Vertical(classes="button-column", id="flatten-buttons"):
+                yield Button("Flatten ->", id="btn-flatten", variant="primary")
+                yield Button("<- Unflatten", id="btn-unflatten", variant="success")
+
+            with Vertical(classes="column"):
+                yield Static("Flattened JSON (dot-separated):", classes="header-label")
+                yield TextArea(id="flat-json", language="json")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        nested_ta = self.query_one("#nested-json", TextArea)
+        flat_ta = self.query_one("#flat-json", TextArea)
+
+        if event.button.id == "btn-flatten":
+            text = nested_ta.text.strip()
+            if not text:
+                self.notify("Please enter nested JSON to flatten.", severity="warning")
+                return
+
+            try:
+                data = json.loads(text)
+                flat_data = self.manager.flatten(data)
+                flat_ta.text = json.dumps(flat_data, indent=2)
+                self.notify("JSON successfully flattened.", severity="information")
+            except json.JSONDecodeError as e:
+                self.notify(f"Invalid JSON: {e}", severity="error")
+            except Exception as e:
+                self.notify(f"Error flattening JSON: {e}", severity="error")
+
+        elif event.button.id == "btn-unflatten":
+            text = flat_ta.text.strip()
+            if not text:
+                self.notify("Please enter flattened JSON to unflatten.", severity="warning")
+                return
+
+            try:
+                data = json.loads(text)
+                if not isinstance(data, dict):
+                    self.notify("Flattened JSON must be an object (dictionary).", severity="error")
+                    return
+
+                nested_data = self.manager.unflatten(data)
+                nested_ta.text = json.dumps(nested_data, indent=2)
+                self.notify("JSON successfully unflattened.", severity="information")
+            except json.JSONDecodeError as e:
+                self.notify(f"Invalid JSON: {e}", severity="error")
+            except Exception as e:
+                self.notify(f"Error unflattening JSON: {e}", severity="error")

--- a/tests/test_flatten_lab.py
+++ b/tests/test_flatten_lab.py
@@ -1,0 +1,105 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import json
+import sys
+from io import StringIO
+from shared.flatten_lab import FlattenManager, run_flatten_lab_logic
+
+class TestFlattenManager(unittest.TestCase):
+    def setUp(self):
+        self.manager = FlattenManager()
+
+    def test_flatten_dict(self):
+        nested = {"user": {"name": "Alice", "address": {"city": "Wonderland"}}}
+        expected = {
+            "user.name": "Alice",
+            "user.address.city": "Wonderland"
+        }
+        self.assertEqual(self.manager.flatten(nested), expected)
+
+    def test_flatten_list(self):
+        nested = {"users": [{"name": "Alice"}, {"name": "Bob"}]}
+        expected = {
+            "users.0.name": "Alice",
+            "users.1.name": "Bob"
+        }
+        self.assertEqual(self.manager.flatten(nested), expected)
+
+    def test_flatten_empty(self):
+        self.assertEqual(self.manager.flatten({}), {})
+        self.assertEqual(self.manager.flatten([]), {})
+
+    def test_flatten_mixed(self):
+        nested = {"a": [1, {"b": 2}]}
+        expected = {"a.0": 1, "a.1.b": 2}
+        self.assertEqual(self.manager.flatten(nested), expected)
+
+    def test_unflatten_dict(self):
+        flat = {
+            "user.name": "Alice",
+            "user.address.city": "Wonderland"
+        }
+        expected = {"user": {"name": "Alice", "address": {"city": "Wonderland"}}}
+        self.assertEqual(self.manager.unflatten(flat), expected)
+
+    def test_unflatten_list(self):
+        flat = {
+            "users.0.name": "Alice",
+            "users.1.name": "Bob"
+        }
+        expected = {"users": [{"name": "Alice"}, {"name": "Bob"}]}
+        self.assertEqual(self.manager.unflatten(flat), expected)
+
+    def test_flatten_custom_separator(self):
+        manager = FlattenManager(separator="_")
+        nested = {"a": {"b": 1}}
+        expected = {"a_b": 1}
+        self.assertEqual(manager.flatten(nested), expected)
+        self.assertEqual(manager.unflatten(expected), nested)
+
+class TestFlattenLabCLI(unittest.TestCase):
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_flatten_cli_text(self, mock_stdout):
+        args = MagicMock()
+        args.action = 'flatten'
+        args.text = '{"a": {"b": 1}}'
+        args.file = None
+        args.output = None
+        args.separator = '.'
+
+        result = run_flatten_lab_logic(args)
+        self.assertTrue(result)
+
+        output = json.loads(mock_stdout.getvalue())
+        self.assertEqual(output, {"a.b": 1})
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_unflatten_cli_text(self, mock_stdout):
+        args = MagicMock()
+        args.action = 'unflatten'
+        args.text = '{"a.b": 1}'
+        args.file = None
+        args.output = None
+        args.separator = '.'
+
+        result = run_flatten_lab_logic(args)
+        self.assertTrue(result)
+
+        output = json.loads(mock_stdout.getvalue())
+        self.assertEqual(output, {"a": {"b": 1}})
+
+    @patch('sys.stderr', new_callable=StringIO)
+    def test_flatten_cli_invalid_json(self, mock_stderr):
+        args = MagicMock()
+        args.action = 'flatten'
+        args.text = '{"a": 1'
+        args.file = None
+        args.output = None
+        args.separator = '.'
+
+        result = run_flatten_lab_logic(args)
+        self.assertFalse(result)
+        self.assertIn("Error parsing JSON", mock_stderr.getvalue())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_tui_flatten.py
+++ b/tests/test_tui_flatten.py
@@ -1,0 +1,51 @@
+import pytest
+from unittest.mock import MagicMock
+from textual.app import App, ComposeResult
+from textual.widgets import TabbedContent
+from shared.tui_flatten import FlattenLabTab
+
+class FlattenLabTestApp(App):
+    def compose(self) -> ComposeResult:
+        with TabbedContent():
+            yield FlattenLabTab()
+
+@pytest.mark.asyncio
+async def test_flatten_lab_tab_flatten_success():
+    app = FlattenLabTestApp()
+    async with app.run_test() as pilot:
+        tab = app.query_one(FlattenLabTab)
+
+        nested_ta = tab.query_one("#nested-json")
+        flat_ta = tab.query_one("#flat-json")
+
+        # Test Flatten
+        nested_ta.text = '{"a": {"b": 2}}'
+        btn_flatten = tab.query_one("#btn-flatten")
+
+        event = MagicMock()
+        event.button.id = btn_flatten.id
+        tab.on_button_pressed(event)
+        await pilot.pause()
+
+        assert '"a.b": 2' in flat_ta.text
+
+@pytest.mark.asyncio
+async def test_flatten_lab_tab_unflatten_success():
+    app = FlattenLabTestApp()
+    async with app.run_test() as pilot:
+        tab = app.query_one(FlattenLabTab)
+
+        nested_ta = tab.query_one("#nested-json")
+        flat_ta = tab.query_one("#flat-json")
+
+        # Test Unflatten
+        flat_ta.text = '{"a.b": 3}'
+        btn_unflatten = tab.query_one("#btn-unflatten")
+
+        event = MagicMock()
+        event.button.id = btn_unflatten.id
+        tab.on_button_pressed(event)
+        await pilot.pause()
+
+        assert '"a": {' in nested_ta.text
+        assert '"b": 3' in nested_ta.text

--- a/ui/app.css
+++ b/ui/app.css
@@ -1,0 +1,11 @@
+
+#flatten-buttons {
+    width: auto;
+    height: 100%;
+    align: center middle;
+    padding: 1;
+}
+
+#flatten-buttons Button {
+    margin: 1 0;
+}


### PR DESCRIPTION
This pull request introduces a missing but highly valuable "JSON Flatten Lab", designed to convert deeply nested JSON strings into flat key-value pairs (using a customizable separator like dot notation), and symmetrically unflattens flat objects back into their original nested representations.

**Key Changes:**
- `shared/flatten_lab.py`: Introduces `FlattenManager` containing the recursive algorithms necessary to safely flatten and unflatten dicts and lists, along with CLI handler logic.
- `shared/tui_flatten.py`: Creates `FlattenLabTab`, an interactive textual UI allowing developers to instantly test flattening JSON without touching the command line.
- `main.py`: Registers the new `json-flatten-lab` subcommand.
- `tests/test_flatten_lab.py` & `tests/test_tui_flatten.py`: Thoroughly test edge cases and correct UI behavior.

**Impact:**
Provides an essential tool for parsing, verifying, and transforming JSON payloads for flat structures like CSV exports, translation files (i18n), and data analysis tools.

---
*PR created automatically by Jules for task [17866354441208769647](https://jules.google.com/task/17866354441208769647) started by @process-failed-successfully*