### PR TITLE
feat: Add TUI tab for Json2Yaml Lab

### DIFF
--- a/main.py
+++ b/main.py
@@ -24307,7 +24307,7 @@ async def main():
             args.action = "json2yaml"
 
         if getattr(args, "tui", False) or args.action == "tui" or not hasattr(args, 'input'):
-            run_tui(args, "tab-yaml2json")
+            run_tui(args, "tab-json2yaml")
             return
         from shared.yaml2json_lab import run_json2yaml_lab_logic
         run_json2yaml_lab_logic(args)

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -330,6 +330,7 @@ from shared.tui_json2kotlin import Json2KotlinTab
 from shared.tui_yaml2py import Yaml2PyLabTab
 from shared.tui_xml2toml import Xml2TomlTab
 from shared.tui_bip39 import Bip39Tab
+from shared.tui_json2yaml import Json2YamlLabTab
 from shared.tui_yaml2json import Yaml2JsonLabTab
 from shared.tui_yaml2toml import Yaml2TomlLabTab
 from shared.tui_toml2json import Toml2JsonLabTab
@@ -4711,6 +4712,8 @@ class AgentTUI(App):
                 yield Toml2CsvLabTab()
             with TabPane("XML to TOML", id="tab-xml2toml"):
                 yield Xml2TomlTab()
+            with TabPane("JSON to YAML", id="tab-json2yaml"):
+                yield Json2YamlLabTab()
             with TabPane("YAML to JSON", id="tab-yaml2json"):
                 yield Yaml2JsonLabTab()
             with TabPane("YAML to TOML", id="tab-yaml2toml"):

--- a/shared/tui_json2yaml.py
+++ b/shared/tui_json2yaml.py
@@ -1,0 +1,80 @@
+from textual.app import ComposeResult
+from textual.containers import Vertical, Horizontal
+from textual.widgets import Static, Button, TextArea, Select, Label
+from textual.binding import Binding
+from shared.yaml2json_lab import Yaml2JsonManager
+
+class Json2YamlLabTab(Static):
+    """TUI tab for Json2Yaml Lab."""
+
+    BINDINGS = [
+        Binding("ctrl+r", "convert", "Convert", show=True),
+    ]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.manager = Yaml2JsonManager()
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="json2yaml-container", classes="p-1"):
+            yield Static("JSON / YAML Converter", classes="text-bold text-center p-1 bg-primary text-primary-content")
+
+            with Horizontal(classes="h-auto p-1 border-b border-primary"):
+                yield Label("Mode:", classes="p-1 mt-1")
+                yield Select(
+                    [("JSON to YAML", "json2yaml"), ("YAML to JSON", "yaml2json")],
+                    value="json2yaml",
+                    id="json2yaml-mode-select",
+                    classes="w-1-3 m-1"
+                )
+                yield Button("Convert (Ctrl+R)", id="json2yaml-convert-btn", variant="primary", classes="m-1")
+
+            with Horizontal(classes="h-full"):
+                with Vertical(classes="w-1-2 p-1 border-r border-primary h-full"):
+                    yield Label("Input:", classes="text-bold mb-1")
+                    yield TextArea(id="json2yaml-input-ta", classes="h-full")
+
+                with Vertical(classes="w-1-2 p-1 h-full"):
+                    yield Label("Output:", classes="text-bold mb-1")
+                    yield TextArea(id="json2yaml-output-ta", classes="h-full", read_only=True)
+
+            yield Static("", id="json2yaml-status", classes="p-1 h-auto")
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "json2yaml-convert-btn":
+            await self.action_convert()
+
+    async def action_convert(self) -> None:
+        mode_select = self.query_one("#json2yaml-mode-select", Select)
+        input_ta = self.query_one("#json2yaml-input-ta", TextArea)
+        output_ta = self.query_one("#json2yaml-output-ta", TextArea)
+        status_static = self.query_one("#json2yaml-status", Static)
+
+        mode = mode_select.value
+        input_text = input_ta.text.strip()
+
+        if mode == Select.BLANK or not isinstance(mode, str):
+            status_static.update("[red]Please select a conversion mode.[/red]")
+            return
+
+        if not input_text:
+            status_static.update("[yellow]Input is empty.[/yellow]")
+            output_ta.text = ""
+            return
+
+        try:
+            if mode == "yaml2json":
+                result = self.manager.convert_yaml_to_json(input_text)
+                output_ta.language = "json"
+            elif mode == "json2yaml":
+                result = self.manager.convert_json_to_yaml(input_text)
+                output_ta.language = "yaml"
+            else:
+                status_static.update(f"[red]Unknown mode: {mode}[/red]")
+                return
+
+            output_ta.text = result
+            status_static.update("[green]Conversion successful.[/green]")
+        except Exception as e:
+            output_ta.text = ""
+            status_static.update(f"[red]Error: {e}[/red]")

--- a/tests/test_tui_json2yaml.py
+++ b/tests/test_tui_json2yaml.py
@@ -1,0 +1,61 @@
+import unittest
+from typing import Any
+from textual.app import App
+from textual.widgets import TextArea, Select, Static
+from shared.tui_json2yaml import Json2YamlLabTab
+
+class DummyApp(App[Any]):
+    def compose(self):
+        yield Json2YamlLabTab()
+
+class TestTuiJson2Yaml(unittest.IsolatedAsyncioTestCase):
+    async def test_convert_json2yaml(self):
+        app = DummyApp()
+        async with app.run_test():
+            tab = app.query_one(Json2YamlLabTab)
+            mode_select = tab.query_one("#json2yaml-mode-select", Select)
+            input_ta = tab.query_one("#json2yaml-input-ta", TextArea)
+            output_ta = tab.query_one("#json2yaml-output-ta", TextArea)
+            status_static = tab.query_one("#json2yaml-status", Static)
+
+            mode_select.value = "json2yaml"
+            input_ta.text = '{"key": "value"}'
+            await tab.action_convert()
+
+            self.assertIn("key: value", output_ta.text)
+            self.assertIn("successful", str(status_static.render()))
+
+    async def test_convert_yaml2json(self):
+        app = DummyApp()
+        async with app.run_test():
+            tab = app.query_one(Json2YamlLabTab)
+            mode_select = tab.query_one("#json2yaml-mode-select", Select)
+            input_ta = tab.query_one("#json2yaml-input-ta", TextArea)
+            output_ta = tab.query_one("#json2yaml-output-ta", TextArea)
+            status_static = tab.query_one("#json2yaml-status", Static)
+
+            mode_select.value = "yaml2json"
+            input_ta.text = "key: value"
+            await tab.action_convert()
+
+            self.assertIn('"key": "value"', output_ta.text)
+            self.assertIn("successful", str(status_static.render()))
+
+    async def test_convert_invalid_input(self):
+        app = DummyApp()
+        async with app.run_test():
+            tab = app.query_one(Json2YamlLabTab)
+            mode_select = tab.query_one("#json2yaml-mode-select", Select)
+            input_ta = tab.query_one("#json2yaml-input-ta", TextArea)
+            output_ta = tab.query_one("#json2yaml-output-ta", TextArea)
+            status_static = tab.query_one("#json2yaml-status", Static)
+
+            mode_select.value = "json2yaml"
+            input_ta.text = '{invalid'
+            await tab.action_convert()
+
+            self.assertEqual(output_ta.text, "")
+            self.assertIn("Error", str(status_static.render()))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented `Json2YamlLabTab` in `shared/tui_json2yaml.py` to provide a Textual UI for the existing JSON/YAML converter. Updated `shared/tui.py` to register the new tab. Updated `main.py` so the `json2yaml-lab --tui` alias loads the correct `tab-json2yaml` interface. Added `tests/test_tui_json2yaml.py` to ensure behavior functions correctly.

---
*PR created automatically by Jules for task [8838183331878825266](https://jules.google.com/task/8838183331878825266) started by @process-failed-successfully*