### PR TITLE
feat: add Zod schema generation support to typegen-lab

### DIFF
--- a/main.py
+++ b/main.py
@@ -20062,7 +20062,7 @@ Examples:
     typegen_generate = typegen_subparsers.add_parser("generate", help="Generate types from JSON")
     typegen_generate.add_argument("--json", help="JSON string to convert")
     typegen_generate.add_argument("--file", "-f", help="Path to JSON file")
-    typegen_generate.add_argument("--lang", "-l", choices=["typescript", "go", "python", "rust"], default="typescript", help="Target language")
+    typegen_generate.add_argument("--lang", "-l", choices=["typescript", "go", "python", "rust", "zod"], default="typescript", help="Target language")
     typegen_generate.add_argument("--name", "-n", default="Root", help="Name of the root struct/interface")
     typegen_generate.add_argument("--output", "-o", help="File to write generated types to")
 

--- a/shared/tui_typegen.py
+++ b/shared/tui_typegen.py
@@ -34,7 +34,7 @@ class TypegenLabTab(Container):
 
                 yield Label("Language:")
                 yield Select.from_values(
-                    ["typescript", "go", "python", "rust"],
+                    ["typescript", "go", "python", "rust", "zod"],
                     id="typegen-lang", value="typescript"
                 )
 
@@ -83,9 +83,11 @@ class TypegenLabTab(Container):
                 prefix = "from dataclasses import dataclass\nfrom typing import Any, List\n\n"
             elif lang == "rust":
                 prefix = "use serde::{Serialize, Deserialize};\n\n"
+            elif lang == "zod":
+                prefix = "import { z } from \"zod\";\n\n"
 
             output.text = prefix + result
-            output.language = lang if lang in ["typescript", "go", "python", "rust"] else None
+            output.language = "typescript" if lang == "zod" else (lang if lang in ["typescript", "go", "python", "rust"] else None)
             log.write("[bold green]✅ Types generated successfully[/bold green]")
         except Exception as e:
             log.write(f"[bold red]Unexpected Error: {e}[/bold red]")

--- a/shared/typegen_lab.py
+++ b/shared/typegen_lab.py
@@ -60,33 +60,35 @@ class TypegenManager:
             self._generate_python(data, name)
         elif lang == "rust":
             self._generate_rust(data, name)
+        elif lang == "zod":
+            self._generate_zod(data, name)
         else:
             self.structs["Error"] = f"Unsupported language: {lang}"
 
     def _get_value_type(self, val: Any, key: str, lang: str) -> str:
         if val is None:
-            return "any" if lang == "typescript" else "interface{}" if lang == "go" else "Any" if lang == "python" else "Option<serde_json::Value>"
+            return "any" if lang == "typescript" else "interface{}" if lang == "go" else "Any" if lang == "python" else "z.any()" if lang == "zod" else "Option<serde_json::Value>"
 
         if isinstance(val, bool):
-            return "boolean" if lang == "typescript" else "bool" if lang == "go" else "bool" if lang == "python" else "bool"
+            return "boolean" if lang == "typescript" else "bool" if lang == "go" else "bool" if lang == "python" else "z.boolean()" if lang == "zod" else "bool"
 
         if isinstance(val, int):
-            return "number" if lang == "typescript" else "int" if lang == "go" else "int" if lang == "python" else "i64"
+            return "number" if lang == "typescript" else "int" if lang == "go" else "int" if lang == "python" else "z.number()" if lang == "zod" else "i64"
 
         if isinstance(val, float):
-            return "number" if lang == "typescript" else "float64" if lang == "go" else "float" if lang == "python" else "f64"
+            return "number" if lang == "typescript" else "float64" if lang == "go" else "float" if lang == "python" else "z.number()" if lang == "zod" else "f64"
 
         if isinstance(val, str):
-            return "string" if lang == "typescript" else "string" if lang == "go" else "str" if lang == "python" else "String"
+            return "string" if lang == "typescript" else "string" if lang == "go" else "str" if lang == "python" else "z.string()" if lang == "zod" else "String"
 
         if isinstance(val, dict):
             nested_name = self._get_type_name(key)
             self._parse_dict(val, nested_name, lang)
-            return nested_name if lang != "go" else f"*{nested_name}"
+            return nested_name if lang not in ("go", "zod") else f"*{nested_name}" if lang == "go" else f"z.lazy(() => {nested_name}Schema)"
 
         if isinstance(val, list):
             if not val:
-                base = "any" if lang == "typescript" else "interface{}" if lang == "go" else "Any" if lang == "python" else "serde_json::Value"
+                base = "any" if lang == "typescript" else "interface{}" if lang == "go" else "Any" if lang == "python" else "z.any()" if lang == "zod" else "serde_json::Value"
             else:
                 base = self._get_value_type(val[0], key, lang)
 
@@ -96,10 +98,12 @@ class TypegenManager:
                 return f"[]{base}"
             elif lang == "python":
                 return f"List[{base}]"
+            elif lang == "zod":
+                return f"z.array({base})"
             elif lang == "rust":
                 return f"Vec<{base}>"
 
-        return "any" if lang == "typescript" else "interface{}" if lang == "go" else "Any" if lang == "python" else "serde_json::Value"
+        return "any" if lang == "typescript" else "interface{}" if lang == "go" else "Any" if lang == "python" else "z.any()" if lang == "zod" else "serde_json::Value"
 
     def _generate_typescript(self, data: Dict[str, Any], name: str):
         lines = [f"export interface {name} {{"]
@@ -147,6 +151,15 @@ class TypegenManager:
         lines.append("}")
         self.structs[name] = "\n".join(lines)
 
+    def _generate_zod(self, data: Dict[str, Any], name: str):
+        lines = [f"export const {name}Schema = z.object({{"]
+        for key, val in data.items():
+            zod_type = self._get_value_type(val, key, "zod")
+            lines.append(f"  {key}: {zod_type},")
+        lines.append("});")
+        lines.append(f"export type {name} = z.infer<typeof {name}Schema>;")
+        self.structs[name] = "\n".join(lines)
+
 
 
 
@@ -189,6 +202,8 @@ def run_typegen_lab_logic(args):
                     f.write("from dataclasses import dataclass\nfrom typing import Any, List\n\n")
                 elif args.lang == "rust" and "serde" in result:
                     f.write("use serde::{Serialize, Deserialize};\n\n")
+                elif args.lang == "zod" and "z.object" in result:
+                    f.write("import { z } from \"zod\";\n\n")
                 f.write(result)
             print(f"✅ Generated types saved to {args.output}")
         except Exception as e:
@@ -199,6 +214,8 @@ def run_typegen_lab_logic(args):
             print("from dataclasses import dataclass\nfrom typing import Any, List\n")
         elif args.lang == "rust" and "serde" in result:
             print("use serde::{Serialize, Deserialize};\n")
+        elif args.lang == "zod" and "z.object" in result:
+            print("import { z } from \"zod\";\n")
         print(result)
 
     return True

--- a/tests/test_tui_typegen.py
+++ b/tests/test_tui_typegen.py
@@ -46,6 +46,13 @@ class TestTypegenLabTab(unittest.IsolatedAsyncioTestCase):
             self.assertIn("@dataclass", output.text)
             self.assertIn("class Root:", output.text)
 
+            # Switch lang to zod
+            lang_select.value = "zod"
+            await pilot.click("#btn-typegen-generate")
+            self.assertIn('import { z } from "zod";', output.text)
+            self.assertIn("export const RootSchema = z.object({", output.text)
+            self.assertIn("name: z.string(),", output.text)
+
     async def test_clear_button(self):
         app = DummyApp()
         async with app.run_test() as pilot:

--- a/tests/test_typegen_lab.py
+++ b/tests/test_typegen_lab.py
@@ -49,6 +49,23 @@ class TestTypegenManager(unittest.TestCase):
         self.assertIn("pub r#type: String,", result)
         self.assertIn("#[serde(rename = \"type\")]", result)
 
+    def test_generate_zod(self):
+        json_str = '{"id": "abc", "count": 10, "isActive": true, "tags": ["admin"]}'
+        result = self.manager.generate(json_str, root_name="Response", lang="zod")
+        self.assertIn("export const ResponseSchema = z.object({", result)
+        self.assertIn("id: z.string(),", result)
+        self.assertIn("count: z.number(),", result)
+        self.assertIn("isActive: z.boolean(),", result)
+        self.assertIn("tags: z.array(z.string()),", result)
+        self.assertIn("export type Response = z.infer<typeof ResponseSchema>;", result)
+
+    def test_generate_zod_nested(self):
+        json_str = '{"user": {"name": "test"}}'
+        result = self.manager.generate(json_str, root_name="Root", lang="zod")
+        self.assertIn("export const UserSchema = z.object({", result)
+        self.assertIn("name: z.string(),", result)
+        self.assertIn("user: z.lazy(() => UserSchema),", result)
+
     def test_generate_nested(self):
         json_str = '{"user": {"name": "test"}}'
         result = self.manager.generate(json_str, root_name="Root", lang="typescript")


### PR DESCRIPTION
This PR adds Zod schema generation capability to the Typegen Lab tool. Zod is extremely popular in modern Typescript codebases, making this feature a high-value productivity booster. Users can now easily paste JSON structures and get fully mapped, recursive Zod schema constants (`z.object`, `z.string`, `z.array`, `z.lazy`) directly via the CLI or TUI. Tests have been written to guarantee output structure and import handling.

---
*PR created automatically by Jules for task [2417521707451455127](https://jules.google.com/task/2417521707451455127) started by @process-failed-successfully*