### PR TITLE
feat: Add KSUID Lab

### DIFF
--- a/main.py
+++ b/main.py
@@ -249,7 +249,7 @@ KNOWN_COMMANDS = [
     "api-lab", "data-lab", "research", "serve", "scheduler", "chaos", "guardrails", "devtools",
     "standup", "presentation", "visualize", "network", "sanitize", "ide", "logic-lab",
     "gantt", "resume", "retro", "kanban", "smart-context", "port", "color-lab", "schema-lab",
-    "cidr-lab", "cidr", "cq", "code-query", "badges", "jwt-lab", "jwk-lab", "jwk", "uuid-lab", "uuid", "ulid-lab", "ulid", "password-lab", "pwd-lab", "hashids-lab", "hashids",
+    "cidr-lab", "cidr", "cq", "code-query", "badges", "jwt-lab", "jwk-lab", "jwk", "ksuid-lab", "ksuid", "uuid-lab", "uuid", "ulid-lab", "ulid", "password-lab", "pwd-lab", "hashids-lab", "hashids",
     "text-lab", "txt", "cert-lab", "cert", "url-lab", "url", "urlencode-lab", "urlencode", "urldecode-lab", "urldecode", "date-lab", "date", "time-lab", "time", "unit-lab", "unit", "converter-lab", "convert",
     "codec-lab", "codec", "currency-lab", "currency", "cur",
     "http-status-lab", "http-status", "status-code",
@@ -2880,6 +2880,27 @@ def run_jwk_lab(args):
     success = run_jwk_lab_logic(args)
     sys.exit(0 if success else 1)
 
+
+def run_ksuid_lab(args):
+    """Runs the KSUID Lab."""
+    if args.action == "tui":
+        from shared.tui import AgentTUI
+        print("Launching KSUID Lab TUI...")
+        app = AgentTUI(project_dir=args.project_dir, start_tab="tab-ksuid")
+        import asyncio
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop and loop.is_running():
+            asyncio.ensure_future(app.run_async())
+        else:
+            app.run()
+        sys.exit(0)
+
+    from shared.ksuid_lab import run_ksuid_lab_logic
+    run_ksuid_lab_logic(args)
+    sys.exit(0)
 
 def run_uuid_lab(args):
     """Runs the UUID Lab."""
@@ -14669,6 +14690,28 @@ def parse_args(argv=None):
     parser_currency.add_argument("--from-cur", dest="from_cur", help="Source currency code (e.g. USD).")
     parser_currency.add_argument("--to-cur", dest="to_cur", help="Target currency code (e.g. EUR).")
 
+    parser_ksuid = subparsers.add_parser(
+        "ksuid-lab",
+        aliases=["ksuid"],
+        help="KSUID Generator and Inspector."
+    )
+    ksuid_subparsers = parser_ksuid.add_subparsers(
+        dest="action",
+        required=True,
+        help="Action to perform."
+    )
+
+    # ksuid generate
+    parser_ksuid_gen = ksuid_subparsers.add_parser("generate", aliases=["gen"], help="Generate KSUIDs.")
+    parser_ksuid_gen.add_argument("--count", "-c", type=int, default=1, help="Number of KSUIDs to generate.")
+
+    # ksuid inspect
+    parser_ksuid_inspect = ksuid_subparsers.add_parser("inspect", aliases=["decode"], help="Inspect a KSUID.")
+    parser_ksuid_inspect.add_argument("ksuid", help="The KSUID to inspect.")
+
+    # ksuid tui
+    parser_ksuid_tui = ksuid_subparsers.add_parser("tui", help="Launch KSUID Lab TUI.")
+
     parser_uuid = subparsers.add_parser(
         "uuid-lab",
         aliases=["uuid"],
@@ -24083,6 +24126,10 @@ async def main():
 
     if args.command in ["jwk-lab", "jwk"]:
         run_jwk_lab(args)
+        return
+
+    if args.command in ["ksuid-lab", "ksuid"]:
+        run_ksuid_lab(args)
         return
 
     if args.command in ["uuid-lab", "uuid"]:

--- a/patch_main.py
+++ b/patch_main.py
@@ -1,0 +1,75 @@
+with open("main.py", "r") as f:
+    content = f.read()
+
+# Add to KNOWN_COMMANDS
+known_cmds_str = '"uuid-lab", "uuid",'
+if '"ksuid-lab", "ksuid",' not in content:
+    content = content.replace(known_cmds_str, '"ksuid-lab", "ksuid", ' + known_cmds_str)
+
+# Add CLI run_ksuid_lab logic block
+run_func_block = """def run_ksuid_lab(args):
+    \"\"\"Runs the KSUID Lab.\"\"\"
+    if args.action == "tui":
+        from shared.tui import AgentTUI
+        print("Launching KSUID Lab TUI...")
+        app = AgentTUI(project_dir=args.project_dir, start_tab="tab-ksuid")
+        import asyncio
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop and loop.is_running():
+            asyncio.ensure_future(app.run_async())
+        else:
+            app.run()
+        sys.exit(0)
+
+    from shared.ksuid_lab import run_ksuid_lab_logic
+    run_ksuid_lab_logic(args)
+    sys.exit(0)
+
+def run_uuid_lab"""
+
+if "def run_ksuid_lab(args):" not in content:
+    content = content.replace("def run_uuid_lab", run_func_block)
+
+# Add subparser registration
+parser_block = """    parser_ksuid = subparsers.add_parser(
+        "ksuid-lab",
+        aliases=["ksuid"],
+        help="KSUID Generator and Inspector."
+    )
+    ksuid_subparsers = parser_ksuid.add_subparsers(
+        dest="action",
+        required=True,
+        help="Action to perform."
+    )
+
+    # ksuid generate
+    parser_ksuid_gen = ksuid_subparsers.add_parser("generate", aliases=["gen"], help="Generate KSUIDs.")
+    parser_ksuid_gen.add_argument("--count", "-c", type=int, default=1, help="Number of KSUIDs to generate.")
+
+    # ksuid inspect
+    parser_ksuid_inspect = ksuid_subparsers.add_parser("inspect", aliases=["decode"], help="Inspect a KSUID.")
+    parser_ksuid_inspect.add_argument("ksuid", help="The KSUID to inspect.")
+
+    # ksuid tui
+    parser_ksuid_tui = ksuid_subparsers.add_parser("tui", help="Launch KSUID Lab TUI.")
+
+    parser_uuid = subparsers.add_parser("""
+
+if "parser_ksuid = subparsers.add_parser(" not in content:
+    content = content.replace("    parser_uuid = subparsers.add_parser(", parser_block)
+
+# Add run command dispatch logic
+dispatch_block = """    if args.command in ["ksuid-lab", "ksuid"]:
+        run_ksuid_lab(args)
+        return
+
+    if args.command in ["uuid-lab", "uuid"]:"""
+
+if "if args.command in [\"ksuid-lab\", \"ksuid\"]:" not in content:
+    content = content.replace("    if args.command in [\"uuid-lab\", \"uuid\"]:", dispatch_block)
+
+with open("main.py", "w") as f:
+    f.write(content)

--- a/patch_test_tui.py
+++ b/patch_test_tui.py
@@ -1,0 +1,16 @@
+with open("tests/test_tui_ksuid.py", "r") as f:
+    content = f.read()
+
+import_statement = "import pytest\n"
+if "pytest.importorskip" not in content:
+    content = content.replace("import pytest\n", "import pytest\npytest.importorskip('textual')\n")
+else:
+    # replace first line with importorskip immediately
+    new_content = "import pytest\npytest.importorskip('textual')\n"
+    for line in content.splitlines()[1:]:
+        if "pytest.importorskip" not in line:
+            new_content += line + "\n"
+    content = new_content
+
+with open("tests/test_tui_ksuid.py", "w") as f:
+    f.write(content)

--- a/patch_test_tui2.py
+++ b/patch_test_tui2.py
@@ -1,0 +1,79 @@
+with open("tests/test_tui_ksuid.py", "r") as f:
+    content = f.read()
+
+# Make it a string so textual logic is inside try-except
+new_content = """import pytest
+
+try:
+    import textual
+    TEXTUAL_AVAILABLE = True
+except ImportError:
+    TEXTUAL_AVAILABLE = False
+
+if TEXTUAL_AVAILABLE:
+    from textual.app import App
+    from textual.widgets import TabbedContent
+    import asyncio
+    from shared.tui_ksuid import KsuidLabTab
+
+    class KsuidTestApp(App):
+        def compose(self):
+            with TabbedContent():
+                yield KsuidLabTab()
+
+@pytest.mark.skipif(not TEXTUAL_AVAILABLE, reason="textual is not installed")
+@pytest.mark.asyncio
+async def test_tui_ksuid_render():
+    app = KsuidTestApp()
+    async with app.run_test() as pilot:
+        assert app.query_one("KsuidLabTab") is not None
+        assert app.query_one("#input-ksuid-count") is not None
+        assert app.query_one("#btn-ksuid-generate") is not None
+        assert app.query_one("#input-ksuid-inspect") is not None
+        assert app.query_one("#btn-ksuid-inspect") is not None
+
+@pytest.mark.skipif(not TEXTUAL_AVAILABLE, reason="textual is not installed")
+@pytest.mark.asyncio
+async def test_tui_ksuid_generate():
+    app = KsuidTestApp()
+    async with app.run_test() as pilot:
+        tab = app.query_one(KsuidLabTab)
+        tab.action_generate()
+        await pilot.pause()
+        log = app.query_one("#log-ksuid-generate")
+        lines = "".join([line.text for line in log.lines])
+        assert len(lines.strip()) == 27
+
+@pytest.mark.skipif(not TEXTUAL_AVAILABLE, reason="textual is not installed")
+@pytest.mark.asyncio
+async def test_tui_ksuid_inspect_empty():
+    app = KsuidTestApp()
+    async with app.run_test() as pilot:
+        tab = app.query_one(KsuidLabTab)
+        tab.action_inspect()
+        await pilot.pause()
+        log = app.query_one("#log-ksuid-inspect")
+        output = "".join([line.text for line in log.lines])
+        assert "Please enter a KSUID" in output
+
+@pytest.mark.skipif(not TEXTUAL_AVAILABLE, reason="textual is not installed")
+@pytest.mark.asyncio
+async def test_tui_ksuid_inspect_valid():
+    from shared.ksuid_lab import KsuidLabManager
+    k = KsuidLabManager().generate()[0]
+
+    app = KsuidTestApp()
+    async with app.run_test() as pilot:
+        tab = app.query_one(KsuidLabTab)
+        app.query_one("#input-ksuid-inspect").value = k
+        tab.action_inspect()
+        await pilot.pause()
+        log = app.query_one("#log-ksuid-inspect")
+        output = "".join([line.text for line in log.lines])
+        assert "Valid KSUID" in output
+        assert "Timestamp:" in output
+        assert "Payload (Hex):" in output
+"""
+
+with open("tests/test_tui_ksuid.py", "w") as f:
+    f.write(new_content)

--- a/patch_tui.py
+++ b/patch_tui.py
@@ -1,0 +1,19 @@
+with open("shared/tui.py", "r") as f:
+    content = f.read()
+
+import_statement = "from shared.tui_uuid import UuidLabTab"
+if "from shared.tui_ksuid import KsuidLabTab" not in content:
+    content = content.replace(import_statement, "from shared.tui_ksuid import KsuidLabTab\n" + import_statement)
+
+yield_statement = """            with TabPane("UUID Lab", id="tab-uuid"):
+                yield UuidLabTab()"""
+
+ksuid_yield = """            with TabPane("KSUID Lab", id="tab-ksuid"):
+                yield KsuidLabTab()
+"""
+
+if 'with TabPane("KSUID Lab", id="tab-ksuid"):' not in content:
+    content = content.replace(yield_statement, ksuid_yield + yield_statement)
+
+with open("shared/tui.py", "w") as f:
+    f.write(content)

--- a/shared/ksuid_lab.py
+++ b/shared/ksuid_lab.py
@@ -1,0 +1,100 @@
+import sys
+import time
+import os
+import struct
+from typing import List, Dict, Any, Optional
+
+KSUID_EPOCH = 1400000000
+BASE62_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+class KsuidLabManager:
+    """Manages KSUID operations (generation, inspection)."""
+
+    def _base62_encode(self, num: int, min_len: int = 27) -> str:
+        if num == 0:
+            return BASE62_ALPHABET[0] * min_len
+        res = []
+        while num > 0:
+            num, rem = divmod(num, 62)
+            res.append(BASE62_ALPHABET[rem])
+        while len(res) < min_len:
+            res.append(BASE62_ALPHABET[0])
+        return "".join(reversed(res))
+
+    def _base62_decode(self, s: str) -> int:
+        num = 0
+        for char in s:
+            num = num * 62 + BASE62_ALPHABET.index(char)
+        return num
+
+    def generate(self, count: int = 1) -> List[str]:
+        """Generates KSUIDs."""
+        results = []
+        for _ in range(count):
+            timestamp = int(time.time()) - KSUID_EPOCH
+            payload = os.urandom(16)
+            packed = struct.pack(">I", timestamp) + payload
+            num = int.from_bytes(packed, byteorder="big")
+            k = self._base62_encode(num, 27)
+            results.append(k)
+        return results
+
+    def inspect(self, ksuid_str: str) -> Dict[str, Any]:
+        """Decodes and inspects a KSUID."""
+        if len(ksuid_str) != 27:
+            return {"valid": False, "error": "Invalid KSUID length. Must be 27 characters."}
+
+        try:
+            num = self._base62_decode(ksuid_str)
+            packed = num.to_bytes(20, byteorder="big")
+        except ValueError:
+            return {"valid": False, "error": "Invalid KSUID format. Must be base62 encoded."}
+        except OverflowError:
+            return {"valid": False, "error": "Invalid KSUID format. Payload too large."}
+
+        ts = struct.unpack(">I", packed[:4])[0]
+        payload = packed[4:]
+
+        info = {
+            "valid": True,
+            "ksuid": ksuid_str,
+            "timestamp": ts,
+            "timestamp_iso": None,
+            "payload_hex": payload.hex(),
+        }
+
+        try:
+            from datetime import datetime, timezone
+            dt = datetime.fromtimestamp(ts + KSUID_EPOCH, tz=timezone.utc)
+            info["timestamp_iso"] = dt.isoformat()
+        except Exception:
+            pass
+
+        return info
+
+
+def run_ksuid_lab_logic(args):
+    """CLI handler for KSUID Lab."""
+    manager = KsuidLabManager()
+
+    if args.action == "generate":
+        try:
+            results = manager.generate(count=args.count)
+            for res in results:
+                print(res)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    elif args.action == "inspect":
+        info = manager.inspect(args.ksuid)
+        if not info["valid"]:
+            print(f"Error: {info['error']}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"--- KSUID Inspection: {args.ksuid} ---")
+        print(f"  Valid:         {info['valid']}")
+        print(f"  Timestamp:     {info['timestamp']}")
+        if info.get("timestamp_iso"):
+            print(f"  Date (UTC):    {info['timestamp_iso']}")
+        print(f"  Payload (Hex): {info['payload_hex']}")

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -221,6 +221,7 @@ from shared.tui_port import PortLabTab
 from shared.tui_har import HarLabTab
 from shared.tui_database import DatabaseTab
 from shared.tui_jwt import JwtLabTab
+from shared.tui_ksuid import KsuidLabTab
 from shared.tui_uuid import UuidLabTab
 from shared.tui_nanoid import NanoIDLab
 from shared.tui_ulid import UlidLabTab
@@ -4510,6 +4511,8 @@ class AgentTUI(App):
                 yield ProxyLabTab(self.project_dir)
             with TabPane("JWT Lab", id="tab-jwt"):
                 yield JwtLabTab()
+            with TabPane("KSUID Lab", id="tab-ksuid"):
+                yield KsuidLabTab()
             with TabPane("UUID Lab", id="tab-uuid"):
                 yield UuidLabTab()
 

--- a/shared/tui_ksuid.py
+++ b/shared/tui_ksuid.py
@@ -1,0 +1,82 @@
+from textual.app import ComposeResult
+from textual.widgets import Label, Button, Input, RichLog, TabbedContent, TabPane, Static
+from textual.containers import Container, Horizontal, Vertical
+from textual import on
+from shared.ksuid_lab import KsuidLabManager
+
+class KsuidLabTab(Container):
+    """Tab for KSUID operations (Generate, Inspect)."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.manager = KsuidLabManager()
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label("[bold]KSUID Lab[/bold]", classes="welcome-text")
+
+            with TabbedContent():
+                # Generate Tab
+                with TabPane("Generate"):
+                    with Vertical(classes="stat-box"):
+                        yield Label("[bold]Generate KSUIDs[/bold]")
+
+                        with Horizontal():
+                            yield Label("Count:")
+                            yield Input(placeholder="1", id="input-ksuid-count", type="integer", value="1")
+
+                        yield Button("Generate", id="btn-ksuid-generate", variant="primary")
+
+                        yield Label("[bold]Output:[/bold]")
+                        yield RichLog(id="log-ksuid-generate", wrap=True, highlight=True, markup=True)
+
+                # Inspect Tab
+                with TabPane("Inspect"):
+                    with Vertical(classes="stat-box"):
+                        yield Label("[bold]Inspect KSUID[/bold]")
+                        yield Input(placeholder="Enter KSUID to inspect", id="input-ksuid-inspect")
+                        yield Button("Inspect", id="btn-ksuid-inspect", variant="primary")
+
+                        yield Label("[bold]Inspection Result:[/bold]")
+                        yield RichLog(id="log-ksuid-inspect", wrap=True, highlight=True, markup=True)
+
+    @on(Button.Pressed, "#btn-ksuid-generate")
+    def action_generate(self) -> None:
+        count_input = self.query_one("#input-ksuid-count", Input).value
+        log = self.query_one("#log-ksuid-generate", RichLog)
+
+        try:
+            count = int(count_input) if count_input else 1
+        except ValueError:
+            log.write("[bold red]Error: Count must be an integer.[/bold red]")
+            return
+
+        try:
+            results = self.manager.generate(count=count)
+            log.clear()
+            for res in results:
+                log.write(res)
+        except Exception as e:
+            log.write(f"[bold red]Error: {e}[/bold red]")
+
+    @on(Button.Pressed, "#btn-ksuid-inspect")
+    def action_inspect(self) -> None:
+        ksuid_input = self.query_one("#input-ksuid-inspect", Input).value
+        log = self.query_one("#log-ksuid-inspect", RichLog)
+        log.clear()
+
+        if not ksuid_input:
+            log.write("[bold red]Please enter a KSUID to inspect.[/bold red]")
+            return
+
+        info = self.manager.inspect(ksuid_input)
+
+        if not info["valid"]:
+            log.write(f"[bold red]Error: {info['error']}[/bold red]")
+            return
+
+        log.write(f"[bold green]Valid KSUID[/bold green]")
+        log.write(f"Timestamp:     {info['timestamp']}")
+        if info.get("timestamp_iso"):
+             log.write(f"Date (UTC):    {info['timestamp_iso']}")
+        log.write(f"Payload (Hex): {info['payload_hex']}")

--- a/test_ksuid.py
+++ b/test_ksuid.py
@@ -1,0 +1,38 @@
+import os, time, struct
+from datetime import datetime, timezone
+
+KSUID_EPOCH = 1400000000
+BASE62_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+def base62_encode(num: int, min_len: int = 27) -> str:
+    if num == 0:
+        return BASE62_ALPHABET[0] * min_len
+    res = []
+    while num > 0:
+        num, rem = divmod(num, 62)
+        res.append(BASE62_ALPHABET[rem])
+    while len(res) < min_len:
+        res.append(BASE62_ALPHABET[0])
+    return ''.join(reversed(res))
+
+def base62_decode(s: str) -> int:
+    num = 0
+    for char in s:
+        num = num * 62 + BASE62_ALPHABET.index(char)
+    return num
+
+timestamp = int(time.time()) - KSUID_EPOCH
+payload = os.urandom(16)
+packed = struct.pack(">I", timestamp) + payload
+num = int.from_bytes(packed, byteorder="big")
+k = base62_encode(num, 27)
+print("KSUID:", k)
+print("Length:", len(k))
+
+num2 = base62_decode(k)
+packed2 = num2.to_bytes(20, byteorder="big")
+ts = struct.unpack(">I", packed2[:4])[0]
+print("Timestamp:", ts)
+print("Original TS:", timestamp)
+print("Payload hex:", packed2[4:].hex())
+print("Original payload hex:", payload.hex())

--- a/test_plan.md
+++ b/test_plan.md
@@ -1,0 +1,16 @@
+I have noticed there is a UUID lab and other ID generator labs (NanoID, Snowflake, ULID), but no KSUID lab.
+
+K-Sortable Globally Unique IDs (KSUIDs) are highly valuable in distributed systems since they are sortable by timestamp, providing an excellent alternative to standard UUIDs.
+
+I propose to implement a `ksuid-lab` tool with the following features:
+1. Generate KSUIDs.
+2. Inspect KSUIDs (decoding and parsing out the timestamp and payload).
+3. A TUI tab for an interactive KSUID lab.
+
+Plan:
+1. Create `shared/ksuid_lab.py` containing a `KsuidLabManager` (generation and inspection logic) and the CLI handler `run_ksuid_lab_logic`.
+2. Create `shared/tui_ksuid.py` containing a `KsuidLabTab` widget for the TUI.
+3. Update `main.py` to register the `ksuid-lab` parser, aliases, subcommands (`generate`, `inspect`, `tui`), and `run_ksuid_lab` dispatch. Also add it to `KNOWN_COMMANDS`.
+4. Update `shared/tui.py` to import and mount the `KsuidLabTab` into the main TUI app.
+5. Create tests in `tests/test_ksuid_lab.py` and `tests/test_tui_ksuid.py` to ensure high test coverage.
+6. Run `run_tests.sh` to ensure nothing is broken and my tests pass.

--- a/tests/test_ksuid_lab.py
+++ b/tests/test_ksuid_lab.py
@@ -1,0 +1,65 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import sys
+import argparse
+from shared.ksuid_lab import KsuidLabManager, run_ksuid_lab_logic
+
+def test_ksuid_generate():
+    manager = KsuidLabManager()
+
+    # Test generation of single KSUID
+    res1 = manager.generate(count=1)
+    assert len(res1) == 1
+    assert len(res1[0]) == 27
+
+    # Test generation of multiple KSUIDs
+    res3 = manager.generate(count=3)
+    assert len(res3) == 3
+    for k in res3:
+        assert len(k) == 27
+
+def test_ksuid_inspect():
+    manager = KsuidLabManager()
+    k = manager.generate(count=1)[0]
+
+    info = manager.inspect(k)
+    assert info["valid"] is True
+    assert info["ksuid"] == k
+    assert "timestamp" in info
+    assert "payload_hex" in info
+    assert "timestamp_iso" in info
+
+def test_ksuid_inspect_invalid_length():
+    manager = KsuidLabManager()
+    info = manager.inspect("too_short")
+    assert info["valid"] is False
+    assert "Invalid KSUID length" in info["error"]
+
+@patch('sys.stdout', new_callable=MagicMock)
+def test_cli_ksuid_generate(mock_stdout):
+    args = argparse.Namespace(action="generate", count=2)
+    run_ksuid_lab_logic(args)
+    output = mock_stdout.write.call_args_list
+    # Since write is called sequentially with a newline, we check for two full strings output
+    assert len([call for call in output if len(call[0][0].strip()) == 27]) == 2
+
+@patch('sys.stdout', new_callable=MagicMock)
+def test_cli_ksuid_inspect(mock_stdout):
+    manager = KsuidLabManager()
+    k = manager.generate()[0]
+    args = argparse.Namespace(action="inspect", ksuid=k)
+
+    run_ksuid_lab_logic(args)
+    output = "".join([call[0][0] for call in mock_stdout.write.call_args_list])
+
+    assert "KSUID Inspection" in output
+    assert k in output
+    assert "Valid:         True" in output
+
+@patch('sys.stderr', new_callable=MagicMock)
+def test_cli_ksuid_inspect_invalid(mock_stderr):
+    args = argparse.Namespace(action="inspect", ksuid="short")
+    with pytest.raises(SystemExit):
+         run_ksuid_lab_logic(args)
+    output = "".join([call[0][0] for call in mock_stderr.write.call_args_list])
+    assert "Invalid KSUID length" in output

--- a/tests/test_tui_ksuid.py
+++ b/tests/test_tui_ksuid.py
@@ -1,0 +1,71 @@
+import pytest
+
+try:
+    import textual
+    TEXTUAL_AVAILABLE = True
+except ImportError:
+    TEXTUAL_AVAILABLE = False
+
+if TEXTUAL_AVAILABLE:
+    from textual.app import App
+    from textual.widgets import TabbedContent
+    import asyncio
+    from shared.tui_ksuid import KsuidLabTab
+
+    class KsuidTestApp(App):
+        def compose(self):
+            with TabbedContent():
+                yield KsuidLabTab()
+
+@pytest.mark.skipif(not TEXTUAL_AVAILABLE, reason="textual is not installed")
+@pytest.mark.asyncio
+async def test_tui_ksuid_render():
+    app = KsuidTestApp()
+    async with app.run_test() as pilot:
+        assert app.query_one("KsuidLabTab") is not None
+        assert app.query_one("#input-ksuid-count") is not None
+        assert app.query_one("#btn-ksuid-generate") is not None
+        assert app.query_one("#input-ksuid-inspect") is not None
+        assert app.query_one("#btn-ksuid-inspect") is not None
+
+@pytest.mark.skipif(not TEXTUAL_AVAILABLE, reason="textual is not installed")
+@pytest.mark.asyncio
+async def test_tui_ksuid_generate():
+    app = KsuidTestApp()
+    async with app.run_test() as pilot:
+        tab = app.query_one(KsuidLabTab)
+        tab.action_generate()
+        await pilot.pause()
+        log = app.query_one("#log-ksuid-generate")
+        lines = "".join([line.text for line in log.lines])
+        assert len(lines.strip()) == 27
+
+@pytest.mark.skipif(not TEXTUAL_AVAILABLE, reason="textual is not installed")
+@pytest.mark.asyncio
+async def test_tui_ksuid_inspect_empty():
+    app = KsuidTestApp()
+    async with app.run_test() as pilot:
+        tab = app.query_one(KsuidLabTab)
+        tab.action_inspect()
+        await pilot.pause()
+        log = app.query_one("#log-ksuid-inspect")
+        output = "".join([line.text for line in log.lines])
+        assert "Please enter a KSUID" in output
+
+@pytest.mark.skipif(not TEXTUAL_AVAILABLE, reason="textual is not installed")
+@pytest.mark.asyncio
+async def test_tui_ksuid_inspect_valid():
+    from shared.ksuid_lab import KsuidLabManager
+    k = KsuidLabManager().generate()[0]
+
+    app = KsuidTestApp()
+    async with app.run_test() as pilot:
+        tab = app.query_one(KsuidLabTab)
+        app.query_one("#input-ksuid-inspect").value = k
+        tab.action_inspect()
+        await pilot.pause()
+        log = app.query_one("#log-ksuid-inspect")
+        output = "".join([line.text for line in log.lines])
+        assert "Valid KSUID" in output
+        assert "Timestamp:" in output
+        assert "Payload (Hex):" in output


### PR DESCRIPTION
Adds a KSUID lab utility that supports generating and inspecting KSUIDs, similar to the existing UUID and Snowflake labs. This includes CLI subcommands `generate`, `inspect`, and `tui`, along with a dedicated TUI tab.

---
*PR created automatically by Jules for task [17095700175466168811](https://jules.google.com/task/17095700175466168811) started by @process-failed-successfully*