### PR TITLE
feat: implement CLI configuration manager for agent launcher

### DIFF
--- a/bin/agent.py
+++ b/bin/agent.py
@@ -2,7 +2,13 @@ import typer
 import subprocess
 import sys
 import os
+import yaml
 from pathlib import Path
+
+# Ensure we can import from shared
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from shared.config_loader import get_config_path, ensure_config_exists
+
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -147,18 +153,84 @@ def stop(name: str):
 @config_app.command("set")
 def config_set(key: str, value: str):
     """Set a configuration value."""
-    # Dummy implementation for now, in a real app this would modify agent_config.yaml
-    console.print(f"Set {key} = {value}")
+    ensure_config_exists()
+    path = get_config_path()
+    try:
+        with open(path, "r") as f:
+            data = yaml.safe_load(f) or {}
+
+        # Parse basic types
+        if value.lower() in ("true", "yes"):
+            parsed_value = True
+        elif value.lower() in ("false", "no"):
+            parsed_value = False
+        else:
+            try:
+                parsed_value = int(value)
+            except ValueError:
+                try:
+                    parsed_value = float(value)
+                except ValueError:
+                    parsed_value = value
+
+        keys = key.split('.')
+        current = data
+        for k in keys[:-1]:
+            if k not in current or not isinstance(current[k], dict):
+                current[k] = {}
+            current = current[k]
+        current[keys[-1]] = parsed_value
+
+        with open(path, "w") as f:
+            yaml.dump(data, f, indent=2, sort_keys=False)
+        console.print(f"[green]Set {key} = {parsed_value}[/green]")
+    except Exception as e:
+        console.print(f"[red]Error setting configuration:[/red] {e}")
 
 @config_app.command("view")
 def config_view():
     """View current configuration."""
-    console.print("Configuration viewer")
+    path = get_config_path()
+    if not path or not path.exists():
+        console.print("[yellow]No configuration file found.[/yellow]")
+        return
+    try:
+        from rich.syntax import Syntax
+        with open(path, "r") as f:
+            content = f.read()
+        syntax = Syntax(content, "yaml", theme="monokai", line_numbers=True)
+        console.print(Panel(syntax, title=f"Configuration: {path}"))
+    except Exception as e:
+        console.print(f"[red]Error reading configuration:[/red] {e}")
 
 @config_app.command("reset")
 def config_reset(key: str):
     """Reset a configuration value to default."""
-    console.print(f"Reset {key}")
+    path = get_config_path()
+    if not path or not path.exists():
+        console.print("[yellow]No configuration file found.[/yellow]")
+        return
+    try:
+        with open(path, "r") as f:
+            data = yaml.safe_load(f) or {}
+
+        keys = key.split('.')
+        current = data
+        for k in keys[:-1]:
+            if k not in current or not isinstance(current[k], dict):
+                console.print(f"[yellow]Key {key} not found.[/yellow]")
+                return
+            current = current[k]
+
+        if keys[-1] in current:
+            del current[keys[-1]]
+            with open(path, "w") as f:
+                yaml.dump(data, f, indent=2, sort_keys=False)
+            console.print(f"[green]Reset {key}[/green]")
+        else:
+            console.print(f"[yellow]Key {key} not found.[/yellow]")
+    except Exception as e:
+        console.print(f"[red]Error resetting configuration:[/red] {e}")
 
 if __name__ == "__main__":
     app()

--- a/tests/test_agent_launcher.py
+++ b/tests/test_agent_launcher.py
@@ -21,20 +21,45 @@ def test_app_help():
     assert "run" in result.stdout
     assert "list" in result.stdout
 
-def test_config_view():
-    result = runner.invoke(app, ["config", "view"])
-    assert result.exit_code == 0
-    assert "Configuration viewer" in result.stdout
+@pytest.fixture
+def mock_config_path(tmp_path, monkeypatch):
+    config_file = tmp_path / "agent_config.yaml"
+    monkeypatch.setattr("bin.agent.get_config_path", lambda: config_file)
+    monkeypatch.setattr("bin.agent.ensure_config_exists", lambda: config_file.touch() if not config_file.exists() else None)
+    return config_file
 
-def test_config_set():
+def test_config_set(mock_config_path):
     result = runner.invoke(app, ["config", "set", "max-iterations", "50"])
     assert result.exit_code == 0
     assert "Set max-iterations = 50" in result.stdout
 
-def test_config_reset():
+    import yaml
+    with open(mock_config_path, "r") as f:
+        data = yaml.safe_load(f)
+    assert data["max-iterations"] == 50
+
+def test_config_view(mock_config_path):
+    import yaml
+    with open(mock_config_path, "w") as f:
+        yaml.dump({"test_key": "test_value"}, f)
+
+    result = runner.invoke(app, ["config", "view"])
+    assert result.exit_code == 0
+    assert "test_key: test_value" in result.stdout
+
+def test_config_reset(mock_config_path):
+    import yaml
+    with open(mock_config_path, "w") as f:
+        yaml.dump({"model": "gemini-1.5-pro", "other": "value"}, f)
+
     result = runner.invoke(app, ["config", "reset", "model"])
     assert result.exit_code == 0
     assert "Reset model" in result.stdout
+
+    with open(mock_config_path, "r") as f:
+        data = yaml.safe_load(f)
+    assert "model" not in data
+    assert data["other"] == "value"
 
 # Mock Docker and Subprocess for other commands
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Implemented the "Dynamic Configuration Management" objective outlined in `app_spec.txt`.

- **`config view`**: Renders the active `agent_config.yaml` with syntax highlighting via `rich.syntax.Syntax`.
- **`config set`**: Allows setting deep configuration keys using dot notation. Handles basic type inference (bool, int, float).
- **`config reset`**: Reverts/deletes a specific configuration key.
- **Testing**: Added unit test coverage for the new subcommands by mocking `get_config_path` via `monkeypatch`. All tests in `tests/test_agent_launcher.py` pass.

---
*PR created automatically by Jules for task [11440698019525316136](https://jules.google.com/task/11440698019525316136) started by @process-failed-successfully*