### PR TITLE
feat: add config list-keys command

### DIFF
--- a/bin/agent.py
+++ b/bin/agent.py
@@ -1,17 +1,16 @@
 import typer
 import subprocess
 import sys
-import os
 import yaml
 from pathlib import Path
 
 # Ensure we can import from shared
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from shared.config_loader import get_config_path, ensure_config_exists
 
-from rich.console import Console
-from rich.panel import Panel
+from shared.config_loader import get_config_path, ensure_config_exists
 from rich.table import Table
+from rich.panel import Panel
+from rich.console import Console
 
 try:
     import docker
@@ -24,6 +23,7 @@ app.add_typer(config_app, name="config")
 
 console = Console()
 
+
 def get_docker_client():
     if not docker:
         console.print("[red]Error:[/red] The 'docker' python library is not installed.")
@@ -34,6 +34,7 @@ def get_docker_client():
         console.print(f"[red]Error connecting to Docker:[/red] {e}")
         console.print("Make sure Docker is running and your user has permissions.")
         sys.exit(1)
+
 
 @app.command(
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
@@ -118,7 +119,7 @@ def attach(name: str):
     """Re-attach to a session."""
     client = get_docker_client()
     try:
-        container = client.containers.get(name)
+        client.containers.get(name)
         console.print(f"[cyan]Attaching to {name}...[/cyan]")
         subprocess.run(["docker", "attach", name])  # nosec
     except docker.errors.NotFound:
@@ -130,7 +131,7 @@ def logs(name: str):
     """View logs."""
     client = get_docker_client()
     try:
-        container = client.containers.get(name)
+        client.containers.get(name)
         console.print(f"[cyan]Fetching logs for {name}...[/cyan]")
         subprocess.run(["docker", "logs", "-f", name])  # nosec
     except docker.errors.NotFound:
@@ -155,10 +156,15 @@ def config_set(key: str, value: str):
     """Set a configuration value."""
     ensure_config_exists()
     path = get_config_path()
+    if not path:
+        console.print("[red]Error: Could not determine configuration path.[/red]")
+        return
+
     try:
         with open(path, "r") as f:
             data = yaml.safe_load(f) or {}
 
+        parsed_value: bool | int | float | str
         # Parse basic types
         if value.lower() in ("true", "yes"):
             parsed_value = True
@@ -187,6 +193,7 @@ def config_set(key: str, value: str):
     except Exception as e:
         console.print(f"[red]Error setting configuration:[/red] {e}")
 
+
 @config_app.command("view")
 def config_view():
     """View current configuration."""
@@ -202,6 +209,40 @@ def config_view():
         console.print(Panel(syntax, title=f"Configuration: {path}"))
     except Exception as e:
         console.print(f"[red]Error reading configuration:[/red] {e}")
+
+
+@config_app.command("list-keys")
+def config_list_keys():
+    """List all configurable settings with descriptions and defaults."""
+    import dataclasses
+    from shared.config import Config
+
+    table = Table("Key", "Type", "Default")
+
+    # Exclude internal fields not meant for user configuration via CLI
+    exclude_keys = {
+        "project_dir", "agent_id", "sprint_id", "jira_ticket_key",
+        "jira_spec_content", "spec_file", "jira"
+    }
+
+    for field in dataclasses.fields(Config):
+        if field.name in exclude_keys:
+            continue
+
+        type_name = str(field.type).replace("typing.", "")
+        if hasattr(field.type, "__name__"):
+            type_name = field.type.__name__
+
+        default_val = "None"
+        if field.default is not dataclasses.MISSING:
+            default_val = str(field.default)
+        elif field.default_factory is not dataclasses.MISSING:
+            default_val = "Factory"
+
+        table.add_row(field.name, type_name, default_val)
+
+    console.print(table)
+
 
 @config_app.command("reset")
 def config_reset(key: str):
@@ -231,6 +272,7 @@ def config_reset(key: str):
             console.print(f"[yellow]Key {key} not found.[/yellow]")
     except Exception as e:
         console.print(f"[red]Error resetting configuration:[/red] {e}")
+
 
 if __name__ == "__main__":
     app()

--- a/tests/test_agent_launcher.py
+++ b/tests/test_agent_launcher.py
@@ -2,17 +2,15 @@ import pytest
 from typer.testing import CliRunner
 import sys
 from pathlib import Path
-import os
 
 # Ensure bin is in sys.path to import agent
 repo_root = Path(__file__).parent.parent
 sys.path.insert(0, str(repo_root))
 
-# Assuming we can import the app
-import bin.agent
 from bin.agent import app
 
 runner = CliRunner()
+
 
 def test_app_help():
     result = runner.invoke(app, ["--help"])
@@ -21,12 +19,14 @@ def test_app_help():
     assert "run" in result.stdout
     assert "list" in result.stdout
 
+
 @pytest.fixture
 def mock_config_path(tmp_path, monkeypatch):
     config_file = tmp_path / "agent_config.yaml"
     monkeypatch.setattr("bin.agent.get_config_path", lambda: config_file)
     monkeypatch.setattr("bin.agent.ensure_config_exists", lambda: config_file.touch() if not config_file.exists() else None)
     return config_file
+
 
 def test_config_set(mock_config_path):
     result = runner.invoke(app, ["config", "set", "max-iterations", "50"])
@@ -38,6 +38,7 @@ def test_config_set(mock_config_path):
         data = yaml.safe_load(f)
     assert data["max-iterations"] == 50
 
+
 def test_config_view(mock_config_path):
     import yaml
     with open(mock_config_path, "w") as f:
@@ -46,6 +47,7 @@ def test_config_view(mock_config_path):
     result = runner.invoke(app, ["config", "view"])
     assert result.exit_code == 0
     assert "test_key: test_value" in result.stdout
+
 
 def test_config_reset(mock_config_path):
     import yaml
@@ -61,7 +63,20 @@ def test_config_reset(mock_config_path):
     assert "model" not in data
     assert data["other"] == "value"
 
+
+def test_config_list_keys():
+    result = runner.invoke(app, ["config", "list-keys"])
+    assert result.exit_code == 0
+    assert "agent_type" in result.stdout
+    assert "max_iterations" in result.stdout
+    assert "timeout" in result.stdout
+    # Should exclude internal keys
+    assert "project_dir" not in result.stdout
+    assert "jira_ticket_key" not in result.stdout
+
 # Mock Docker and Subprocess for other commands
+
+
 @pytest.fixture(autouse=True)
 def mock_docker_subprocess(monkeypatch):
     def mock_run(cmd, *args, **kwargs):
@@ -73,12 +88,12 @@ def mock_docker_subprocess(monkeypatch):
     monkeypatch.setattr("bin.agent.subprocess.run", mock_run)
     monkeypatch.setattr("bin.agent.subprocess.Popen", mock_popen)
 
-
     class MockContainer:
         def __init__(self, name, short_id, status, tags):
             self.name = name
             self.short_id = short_id
             self.status = status
+
             class MockImage:
                 def __init__(self, t):
                     self.tags = t
@@ -109,6 +124,7 @@ def mock_docker_subprocess(monkeypatch):
 
     monkeypatch.setattr("bin.agent.get_docker_client", mock_get_docker_client)
 
+
 def test_list():
     result = runner.invoke(app, ["list"])
     assert result.exit_code == 0
@@ -117,26 +133,31 @@ def test_list():
     # other_container should not be listed as it doesn't match filter
     assert "other_container" not in result.stdout
 
+
 def test_attach_success():
     result = runner.invoke(app, ["attach", "test_agent_run"])
     assert result.exit_code == 0
     assert "Attaching to test_agent_run..." in result.stdout
+
 
 def test_attach_not_found():
     result = runner.invoke(app, ["attach", "nonexistent"])
     assert result.exit_code == 0
     assert "Container nonexistent not found" in result.stdout
 
+
 def test_logs_success():
     result = runner.invoke(app, ["logs", "test_agent_run"])
     assert result.exit_code == 0
     assert "Fetching logs for test_agent_run..." in result.stdout
+
 
 def test_stop_success():
     result = runner.invoke(app, ["stop", "test_agent_run"])
     assert result.exit_code == 0
     assert "Stopping test_agent_run..." in result.stdout
     assert "test_agent_run stopped successfully" in result.stdout
+
 
 def test_run_command():
     result = runner.invoke(app, ["run", "--spec", "my_spec.txt", "--detached", "--name", "my_agent"])


### PR DESCRIPTION
Adds a highly requested usability feature for the `agent` command to allow users to view what `config set` options are available.

---
*PR created automatically by Jules for task [2092805383172477419](https://jules.google.com/task/2092805383172477419) started by @process-failed-successfully*