### PR TITLE
feat: Add JSON to Dart class converter (json2dart-lab)

### DIFF
--- a/main.py
+++ b/main.py
@@ -258,7 +258,7 @@ KNOWN_COMMANDS = [
     "bencode-lab", "bencode", "torrent",
     "msgpack-lab", "msgpack", "mpack",
     "bson-lab", "bson",
-    "crypto-lab", "crypto", "json-lab", "json", "csv-lab", "csv", "csv2sql-lab", "csv2sql", "c2s", "json2sql-lab", "json2sql", "j2s", "csv2html-lab", "csv2html", "c2h", "json2csv-lab", "j2c", "csv2json-lab", "c2j", "csv2yaml-lab", "csv2yaml", "c2y", "env2json-lab", "env2json", "json2env", "json2md-lab", "json2md", "csv2md-lab", "csv2md", "md2csv-lab", "md2csv", "m2c", "csv2toml-lab", "csv2toml", "c2t", "yaml2csv-lab", "yaml2csv", "y2c", "xml2csv-lab", "xml2csv", "x2c", "toml2csv-lab", "toml2csv", "t2c", "yaml2json-lab", "yaml2json", "y2j", "json2py-lab", "json2py", "j2py", "json2yaml-lab", "json2yaml", "j2y", "yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t", "xml2toml-lab", "xml2toml", "toml2xml", "x2t", "json2toml-lab", "json2toml", "j2t", "xml2yaml-lab", "xml2yaml", "x2y", "yaml2xml-lab", "yaml2xml", "y2x", "yaml2py-lab", "yaml2py", "y2py", "json2ts-lab", "json2ts", "j2ts", "json2go-lab", "json2go", "j2go", "json2csharp-lab", "json2csharp", "j2cs", "json2rust-lab", "json2rust", "j2rs", "excel-lab", "xls", "xlsx", "excel", "template-lab", "tpl", "image-lab", "img", "exif-lab", "exif", "ocr-lab", "ocr", "media-lab", "media", "xml-lab", "xml", "lorem-lab", "lorem", "lipsum", "bip39-lab", "bip39", "magic-decode-lab", "magic-decode", "mdecode", "endian-lab", "endian",
+    "crypto-lab", "crypto", "json-lab", "json", "csv-lab", "csv", "csv2sql-lab", "csv2sql", "c2s", "json2sql-lab", "json2sql", "j2s", "csv2html-lab", "csv2html", "c2h", "json2csv-lab", "j2c", "csv2json-lab", "c2j", "csv2yaml-lab", "csv2yaml", "c2y", "env2json-lab", "env2json", "json2env", "json2md-lab", "json2md", "csv2md-lab", "csv2md", "md2csv-lab", "md2csv", "m2c", "csv2toml-lab", "csv2toml", "c2t", "yaml2csv-lab", "yaml2csv", "y2c", "xml2csv-lab", "xml2csv", "x2c", "toml2csv-lab", "toml2csv", "t2c", "yaml2json-lab", "yaml2json", "y2j", "json2py-lab", "json2py", "j2py", "json2yaml-lab", "json2yaml", "j2y", "yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t", "xml2toml-lab", "xml2toml", "toml2xml", "x2t", "json2toml-lab", "json2toml", "j2t", "xml2yaml-lab", "xml2yaml", "x2y", "yaml2xml-lab", "yaml2xml", "y2x", "yaml2py-lab", "yaml2py", "y2py", "json2ts-lab", "json2ts", "j2ts", "json2go-lab", "json2go", "j2go", "json2dart-lab", "json2dart", "j2dart", "json2csharp-lab", "json2csharp", "j2cs", "json2rust-lab", "json2rust", "j2rs", "excel-lab", "xls", "xlsx", "excel", "template-lab", "tpl", "image-lab", "img", "exif-lab", "exif", "ocr-lab", "ocr", "media-lab", "media", "xml-lab", "xml", "lorem-lab", "lorem", "lipsum", "bip39-lab", "bip39", "magic-decode-lab", "magic-decode", "mdecode", "endian-lab", "endian",
     "ical-lab", "ical", "ics",
     "markdown-lab", "md", "md-lab", "yaml-lab", "yaml", "ini-lab", "ini", "toml-lab", "toml", "net-lab", "net", "archive-lab", "arc",
     "plist-lab", "plist", "plist2json", "json2plist",
@@ -15968,6 +15968,18 @@ def parse_args(argv=None):
     parser_json2rust.add_argument("--name", "-n", default="RootStruct", help="Root struct name (default: 'RootStruct').")
     parser_json2rust.add_argument("--tui", action="store_true", help="Launch JSON to Rust Lab TUI.")
 
+    # --- New 'json2dart-lab' command ---
+    parser_json2dart = subparsers.add_parser(
+        "json2dart-lab",
+        aliases=["json2dart", "j2dart"],
+        help="Convert JSON to Dart Classes."
+    )
+    parser_json2dart.add_argument("--file", "-f", help="Input JSON file path.")
+    parser_json2dart.add_argument("--text", "-t", help="Input JSON string directly.")
+    parser_json2dart.add_argument("--name", help="Root class name (default: RootClass).")
+    parser_json2dart.add_argument("--output", "-o", help="Output file path (optional).")
+    parser_json2dart.add_argument("--tui", action="store_true", help="Launch the JSON2Dart Lab TUI.")
+
     # --- New 'json2csharp-lab' command ---
     parser_json2csharp = subparsers.add_parser(
         "json2csharp-lab",
@@ -24652,6 +24664,14 @@ async def main():
 
         from shared.csv2sql_lab import run_csv2sql_lab_logic
         success = run_csv2sql_lab_logic(args)
+        sys.exit(0 if success else 1)
+
+    if args.command in ["json2dart-lab", "json2dart", "j2dart"]:
+        if getattr(args, "tui", False):
+            run_tui(args, "tab-json2dart")
+            return
+        from shared.json2dart_lab import run_json2dart_lab_logic
+        success = run_json2dart_lab_logic(args)
         sys.exit(0 if success else 1)
 
     if args.command in ["json2sql-lab", "json2sql", "j2s"]:

--- a/shared/json2dart_lab.py
+++ b/shared/json2dart_lab.py
@@ -1,0 +1,229 @@
+import argparse
+import json
+import sys
+
+class Json2DartManager:
+    """Manages conversion from JSON to Dart classes."""
+
+    def __init__(self):
+        self.classes = {}
+
+    def _to_camel_case(self, s: str, first_upper: bool = False) -> str:
+        if not s:
+            return "NestedClass"
+
+        import re
+        s = re.sub(r'[^a-zA-Z0-9]', ' ', s)
+
+        words = s.split()
+        if not words:
+            return "NestedClass"
+
+        if first_upper:
+            return "".join(w[0].upper() + w[1:] for w in words)
+        else:
+            return words[0][0].lower() + words[0][1:] + "".join(w[0].upper() + w[1:] for w in words[1:])
+
+    def convert(self, json_data: str, root_name: str = "RootClass") -> str:
+        """Converts JSON string to Dart classes."""
+        self.classes = {}
+        try:
+            data = json.loads(json_data)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON: {e}")
+
+        def _get_type(value, name):
+            if isinstance(value, dict):
+                class_name = self._to_camel_case(name, first_upper=True)
+
+                if not class_name or class_name.lower() in ("string", "double", "int", "bool", "dynamic"):
+                    class_name = "Object"
+
+                _generate_class(value, class_name)
+                return class_name
+            elif isinstance(value, list):
+                if not value:
+                    return "List<dynamic>"
+
+                item_name = name
+                if name.endswith("s") and len(name) > 1:
+                    item_name = name[:-1]
+                elif name.endswith("List") and len(name) > 4:
+                    item_name = name[:-4]
+
+                item_type = _get_type(value[0], item_name)
+                return f"List<{item_type}>"
+            elif isinstance(value, str):
+                return "String"
+            elif isinstance(value, bool):
+                return "bool"
+            elif isinstance(value, int):
+                return "int"
+            elif isinstance(value, float):
+                return "double"
+            elif value is None:
+                return "dynamic"
+            else:
+                return "dynamic"
+
+        def _generate_class(obj: dict, name: str):
+            if not isinstance(obj, dict):
+                return
+
+            original_name = name
+            counter = 1
+            while name in self.classes:
+                # To prevent overriding if we have similar names with different structures
+                # (Simple approach: just create a new name)
+                name = f"{original_name}{counter}"
+                counter += 1
+
+            lines = [f"class {name} {{"]
+
+            # Fields
+            for k, v in obj.items():
+                prop_type = _get_type(v, k)
+                dart_field_name = self._to_camel_case(k)
+                if not dart_field_name or dart_field_name[0].isdigit():
+                    dart_field_name = "field" + dart_field_name.capitalize()
+
+                # Make dynamic or nullable based on nullability logic, for MVP keep it simple
+                # use nullable for all basic types except dynamic since dynamic is already nullable in Dart
+                if prop_type != "dynamic":
+                    lines.append(f"  {prop_type}? {dart_field_name};")
+                else:
+                    lines.append(f"  {prop_type} {dart_field_name};")
+
+            lines.append("")
+
+            # Constructor
+            lines.append(f"  {name}({{")
+            for k, v in obj.items():
+                dart_field_name = self._to_camel_case(k)
+                if not dart_field_name or dart_field_name[0].isdigit():
+                    dart_field_name = "field" + dart_field_name.capitalize()
+                lines.append(f"    this.{dart_field_name},")
+            lines.append("  });")
+            lines.append("")
+
+            # fromJson
+            lines.append(f"  factory {name}.fromJson(Map<String, dynamic> json) {{")
+            lines.append(f"    return {name}(")
+            for k, v in obj.items():
+                prop_type = _get_type(v, k)
+                dart_field_name = self._to_camel_case(k)
+                if not dart_field_name or dart_field_name[0].isdigit():
+                    dart_field_name = "field" + dart_field_name.capitalize()
+
+                if prop_type.startswith("List<"):
+                    inner_type = prop_type[5:-1]
+                    if inner_type in ("String", "int", "double", "bool", "dynamic"):
+                        lines.append(f"      {dart_field_name}: json['{k}'] != null ? List<{inner_type}>.from(json['{k}']) : null,")
+                    else:
+                        lines.append(f"      {dart_field_name}: json['{k}'] != null ? (json['{k}'] as List).map((i) => {inner_type}.fromJson(i)).toList() : null,")
+                elif prop_type not in ("String", "int", "double", "bool", "dynamic"):
+                    lines.append(f"      {dart_field_name}: json['{k}'] != null ? {prop_type}.fromJson(json['{k}']) : null,")
+                else:
+                    lines.append(f"      {dart_field_name}: json['{k}'],")
+            lines.append("    );")
+            lines.append("  }")
+            lines.append("")
+
+            # toJson
+            lines.append("  Map<String, dynamic> toJson() {")
+            lines.append("    final Map<String, dynamic> data = <String, dynamic>{};")
+            for k, v in obj.items():
+                prop_type = _get_type(v, k)
+                dart_field_name = self._to_camel_case(k)
+                if not dart_field_name or dart_field_name[0].isdigit():
+                    dart_field_name = "field" + dart_field_name.capitalize()
+
+                if prop_type.startswith("List<"):
+                    inner_type = prop_type[5:-1]
+                    if inner_type in ("String", "int", "double", "bool", "dynamic"):
+                        lines.append(f"    data['{k}'] = this.{dart_field_name};")
+                    else:
+                        lines.append(f"    if (this.{dart_field_name} != null) {{")
+                        lines.append(f"      data['{k}'] = this.{dart_field_name}!.map((v) => v.toJson()).toList();")
+                        lines.append(f"    }}")
+                elif prop_type not in ("String", "int", "double", "bool", "dynamic"):
+                    lines.append(f"    if (this.{dart_field_name} != null) {{")
+                    lines.append(f"      data['{k}'] = this.{dart_field_name}!.toJson();")
+                    lines.append(f"    }}")
+                else:
+                    lines.append(f"    data['{k}'] = this.{dart_field_name};")
+            lines.append("    return data;")
+            lines.append("  }")
+
+            lines.append("}")
+            self.classes[name] = "\n".join(lines)
+
+        if isinstance(data, dict):
+            _generate_class(data, root_name)
+        elif isinstance(data, list):
+            item_type = _get_type(data, root_name)
+            if item_type in self.classes:
+                pass
+            return "\n\n".join(list(self.classes.values()))
+        else:
+            return f"// Unsupported root type: {type(data)}"
+
+        return "\n\n".join(list(self.classes.values()))
+
+
+def run_json2dart_lab_logic(args: argparse.Namespace) -> bool:
+    """CLI handler for Json2Dart Lab."""
+    manager = Json2DartManager()
+
+    if getattr(args, "tui", False):
+        from shared.tui import AgentTUI
+        print("Launching JSON to Dart Lab TUI...")
+        app = AgentTUI(project_dir=getattr(args, 'project_dir', None), start_tab="tab-json2dart")
+        import asyncio
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop and loop.is_running():
+            asyncio.ensure_future(app.run_async())
+        else:
+            app.run()
+            sys.exit(0)
+        return True
+
+    input_data = ""
+    if getattr(args, "file", None):
+        try:
+            with open(args.file, "r", encoding="utf-8") as f:
+                input_data = f.read()
+        except Exception as e:
+            print(f"Error reading file {args.file}: {e}", file=sys.stderr)
+            return False
+    elif getattr(args, "text", None):
+        input_data = args.text
+    else:
+        # read from stdin
+        if not sys.stdin.isatty():
+            input_data = sys.stdin.read()
+        else:
+            print("Error: No input provided. Use --file, --text, or pipe via stdin.", file=sys.stderr)
+            return False
+
+    if not input_data.strip():
+        print("Error: Empty input data.", file=sys.stderr)
+        return False
+
+    root_name = getattr(args, "name", "RootClass")
+
+    try:
+        result = manager.convert(input_data, root_name)
+        if getattr(args, "output", None):
+            with open(args.output, "w", encoding="utf-8") as f:
+                f.write(result)
+            print(f"Output written to {args.output}")
+        else:
+            print(result)
+        return True
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return False

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -324,6 +324,7 @@ from shared.tui_xml2csv import Xml2CsvTab
 from shared.tui_json2ts import Json2TsLabTab
 from shared.tui_json2go import Json2GoLabTab
 from shared.tui_json2rust import Json2RustLabTab
+from shared.tui_json2dart import Json2DartLabTab
 from shared.tui_json2csharp import Json2CSharpTab
 from shared.tui_xml2yaml import Xml2YamlTab
 from shared.tui_flatten import FlattenLabTab
@@ -4200,6 +4201,7 @@ class AgentTUI(App):
         PaletteCommand("Go to JSON to Py Lab", "switch_tab_json2py"),
         PaletteCommand("Go to JSON to TS Lab", "switch_tab_json2ts"),
         PaletteCommand("Go to JSON to Go Lab", "switch_tab_json2go"),
+        PaletteCommand("Go to JSON to Dart Lab", "switch_tab_json2dart"),
         PaletteCommand("Go to JSON to Rust Lab", "switch_tab_json2rust"),
         PaletteCommand("Go to JSON to Kotlin Lab", "switch_tab_json2kotlin"),
         PaletteCommand("Go to JSON to SQL Lab", "switch_tab_json2sql"),
@@ -4698,6 +4700,8 @@ class AgentTUI(App):
                 yield Json2TsLabTab()
             with TabPane("JSON to Go", id="tab-json2go"):
                 yield Json2GoLabTab()
+            with TabPane("JSON to Dart", id="tab-json2dart"):
+                yield Json2DartLabTab()
             with TabPane("JSON to Rust", id="tab-json2rust"):
                 yield Json2RustLabTab()
             with TabPane("JSON to C#", id="tab-json2csharp"):
@@ -4972,6 +4976,9 @@ class AgentTUI(App):
 
     def action_switch_tab_json2go(self) -> None:
         self.query_one(TabbedContent).active = "tab-json2go"
+
+    def action_switch_tab_json2dart(self) -> None:
+        self.query_one(TabbedContent).active = "tab-json2dart"
 
     def action_switch_tab_json2sql(self) -> None:
         self.query_one(TabbedContent).active = "tab-json2sql"

--- a/shared/tui_json2dart.py
+++ b/shared/tui_json2dart.py
@@ -1,0 +1,66 @@
+from textual.app import ComposeResult
+from textual.containers import Vertical, Horizontal
+from textual.widgets import Static, Button, TextArea, Input, Label
+from textual.binding import Binding
+from shared.json2dart_lab import Json2DartManager
+
+
+class Json2DartLabTab(Static):
+    """TUI tab for Json2Dart Lab."""
+
+    BINDINGS = [
+        Binding("ctrl+r", "convert", "Convert", show=True),
+    ]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.manager = Json2DartManager()
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="json2dart-container", classes="p-1"):
+            yield Static("JSON to Dart Converter", classes="text-bold text-center p-1 bg-primary text-primary-content")
+
+            with Horizontal(classes="h-auto p-1 border-b border-primary"):
+                yield Label("Root Class Name:", classes="p-1 mt-1")
+                yield Input(value="RootClass", id="json2dart-name-input", classes="w-1-3 m-1")
+                yield Button("Convert (Ctrl+R)", id="json2dart-convert-btn", variant="primary", classes="m-1")
+
+            with Horizontal(classes="h-full"):
+                with Vertical(classes="w-1-2 p-1 border-r border-primary h-full"):
+                    yield Label("JSON Input:", classes="text-bold mb-1")
+                    yield TextArea(id="json2dart-input-ta", classes="h-full", language="json")
+
+                with Vertical(classes="w-1-2 p-1 h-full"):
+                    yield Label("Dart Output:", classes="text-bold mb-1")
+                    # Dart is supported in rich/textual textareas, but let's just use generic or java-like if missing
+                    # Actually standard generic is fine, or we can omit language if it causes issues.
+                    # We will omit language to avoid LanguageDoesNotExist error if textual version lacks 'dart'
+                    yield TextArea(id="json2dart-output-ta", classes="h-full", read_only=True)
+
+            yield Static("", id="json2dart-status", classes="p-1 h-auto")
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "json2dart-convert-btn":
+            await self.action_convert()
+
+    async def action_convert(self) -> None:
+        name_input = self.query_one("#json2dart-name-input", Input)
+        input_ta = self.query_one("#json2dart-input-ta", TextArea)
+        output_ta = self.query_one("#json2dart-output-ta", TextArea)
+        status_static = self.query_one("#json2dart-status", Static)
+
+        root_name = name_input.value.strip() or "RootClass"
+        input_text = input_ta.text.strip()
+
+        if not input_text:
+            status_static.update("[yellow]Input is empty.[/yellow]")
+            output_ta.text = ""
+            return
+
+        try:
+            result = self.manager.convert(input_text, root_name=root_name)
+            output_ta.text = result
+            status_static.update("[green]Conversion successful.[/green]")
+        except Exception as e:
+            output_ta.text = ""
+            status_static.update(f"[red]Error: {e}[/red]")

--- a/tests/test_json2dart_lab.py
+++ b/tests/test_json2dart_lab.py
@@ -1,0 +1,117 @@
+import pytest
+from textual.app import App
+from typing import Any
+import unittest
+from unittest.mock import patch
+import io
+import argparse
+import sys
+
+from shared.json2dart_lab import Json2DartManager, run_json2dart_lab_logic
+from shared.tui_json2dart import Json2DartLabTab
+from textual.widgets import TextArea, Input, Static
+
+
+class TestJson2DartManager:
+    @pytest.fixture
+    def manager(self):
+        return Json2DartManager()
+
+    def test_basic_conversion(self, manager):
+        json_data = '{"name": "Alice", "age": 30, "isActive": true}'
+        dart_code = manager.convert(json_data, "User")
+
+        assert "class User {" in dart_code
+        assert "String? name;" in dart_code
+        assert "int? age;" in dart_code
+        assert "bool? isActive;" in dart_code
+        assert "User({" in dart_code
+        assert "this.name," in dart_code
+        assert "factory User.fromJson(Map<String, dynamic> json)" in dart_code
+        assert "Map<String, dynamic> toJson()" in dart_code
+
+    def test_nested_objects(self, manager):
+        json_data = '{"user": {"name": "Bob"}}'
+        dart_code = manager.convert(json_data, "Response")
+
+        assert "class User {" in dart_code
+        assert "class Response {" in dart_code
+        assert "User? user;" in dart_code
+        assert "User.fromJson(json['user'])" in dart_code
+
+    def test_lists(self, manager):
+        json_data = '{"items": [{"id": 1}], "tags": ["a", "b"]}'
+        dart_code = manager.convert(json_data, "Data")
+
+        assert "class Item {" in dart_code
+        assert "List<Item>? items;" in dart_code
+        assert "List<String>? tags;" in dart_code
+        assert "(json['items'] as List).map((i) => Item.fromJson(i)).toList()" in dart_code
+        assert "List<String>.from(json['tags'])" in dart_code
+
+    def test_invalid_json(self, manager):
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            manager.convert('{"bad": json')
+
+def test_run_json2dart_lab_logic_cli_stdout():
+    args = argparse.Namespace(action=None, text='{"key": "value"}', file=None, name="MyClass", output=None, tui=False)
+    with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+        success = run_json2dart_lab_logic(args)
+
+    assert success is True
+    output = mock_stdout.getvalue()
+    assert "class MyClass" in output
+    assert "String? key;" in output
+
+
+class DummyApp(App[Any]):
+    def compose(self):
+        yield Json2DartLabTab()
+
+
+class TestJson2DartLabTab(unittest.IsolatedAsyncioTestCase):
+    async def test_convert_ui(self):
+        app = DummyApp()
+        async with app.run_test() as pilot:
+            input_ta = app.query_one("#json2dart-input-ta", TextArea)
+            input_ta.text = '{"name": "test"}'
+
+            name_input = app.query_one("#json2dart-name-input", Input)
+            name_input.value = "TestClass"
+
+            btn = app.query_one("#json2dart-convert-btn")
+            event = unittest.mock.MagicMock()
+            event.button.id = btn.id
+            await app.query_one('Json2DartLabTab').on_button_pressed(event)
+
+            output_ta = app.query_one("#json2dart-output-ta", TextArea)
+            assert "class TestClass" in output_ta.text
+            assert "String? name;" in output_ta.text
+
+            status = app.query_one("#json2dart-status", Static)
+            assert "Conversion successful" in str(status.render())
+
+    async def test_empty_input_ui(self):
+        app = DummyApp()
+        async with app.run_test() as pilot:
+            btn = app.query_one("#json2dart-convert-btn")
+            event = unittest.mock.MagicMock()
+            event.button.id = btn.id
+            await app.query_one('Json2DartLabTab').on_button_pressed(event)
+
+            status = app.query_one("#json2dart-status", Static)
+            assert "Input is empty" in str(status.render())
+
+    async def test_invalid_input_ui(self):
+        app = DummyApp()
+        async with app.run_test() as pilot:
+            input_ta = app.query_one("#json2dart-input-ta", TextArea)
+            input_ta.text = '{"invalid":'
+
+            btn = app.query_one("#json2dart-convert-btn")
+            event = unittest.mock.MagicMock()
+            event.button.id = btn.id
+            await app.query_one('Json2DartLabTab').on_button_pressed(event)
+
+            status = app.query_one("#json2dart-status", Static)
+            assert "Error" in str(status.render())


### PR DESCRIPTION
Adds a JSON to Dart class converter (json2dart-lab), which generates strongly-typed Dart classes from JSON payloads. It supports nested classes, properties, constructors, and factory `fromJson`/`toJson` methods. It is available via CLI arguments and the Textual TUI.

---
*PR created automatically by Jules for task [7006921856731218245](https://jules.google.com/task/7006921856731218245) started by @process-failed-successfully*