### PR TITLE
feat: add argon2-lab for secure password hashing

### DIFF
--- a/main.py
+++ b/main.py
@@ -249,7 +249,7 @@ KNOWN_COMMANDS = [
     "api-lab", "data-lab", "research", "serve", "scheduler", "chaos", "guardrails", "devtools",
     "standup", "presentation", "visualize", "network", "sanitize", "ide", "logic-lab",
     "gantt", "resume", "retro", "kanban", "smart-context", "port", "color-lab", "schema-lab",
-    "cidr-lab", "cidr", "cq", "code-query", "badges", "jwt-lab", "jwk-lab", "jwk", "ksuid-lab", "ksuid", "uuid-lab", "uuid", "cuid2-lab", "cuid2", "ulid-lab", "ulid", "password-lab", "pwd-lab", "hashids-lab", "hashids",
+    "cidr-lab", "cidr", "cq", "code-query", "badges", "jwt-lab", "jwk-lab", "jwk", "ksuid-lab", "ksuid", "uuid-lab", "uuid", "cuid2-lab", "cuid2", "ulid-lab", "ulid", "password-lab", "pwd-lab", "hashids-lab", "hashids", "argon2-lab", "argon2",
     "text-lab", "txt", "cert-lab", "cert", "url-lab", "url", "urlencode-lab", "urlencode", "urldecode-lab", "urldecode", "date-lab", "date", "time-lab", "time", "unit-lab", "unit", "converter-lab", "convert",
     "codec-lab", "codec", "currency-lab", "currency", "cur",
     "http-status-lab", "http-status", "status-code",
@@ -14781,6 +14781,31 @@ def parse_args(argv=None):
     parser_uuid_extract.add_argument("--file", help="File to extract from.")
     parser_uuid_extract.add_argument("--unique", action="store_true", help="Return only unique UUIDs.")
 
+# --- New 'argon2-lab' command ---
+    parser_argon2 = subparsers.add_parser(
+        "argon2-lab",
+        aliases=["argon2"],
+        help="Argon2 password hashing and verification."
+    )
+    argon2_subparsers = parser_argon2.add_subparsers(
+        dest="action",
+        required=True,
+        help="Action to perform."
+    )
+
+    # argon2-lab hash
+    parser_argon2_hash = argon2_subparsers.add_parser("hash", help="Hash a password.")
+    parser_argon2_hash.add_argument("password", nargs="?", help="Password to hash (prompts if omitted).")
+    parser_argon2_hash.add_argument("--time-cost", type=int, default=3, help="Time cost (iterations). Default: 3.")
+    parser_argon2_hash.add_argument("--memory-cost", type=int, default=65536, help="Memory cost in kibibytes. Default: 65536.")
+    parser_argon2_hash.add_argument("--parallelism", type=int, default=4, help="Number of threads. Default: 4.")
+    parser_argon2_hash.add_argument("--hash-len", type=int, default=32, help="Length of the hash. Default: 32.")
+
+    # argon2-lab verify
+    parser_argon2_verify = argon2_subparsers.add_parser("verify", help="Verify a password against an Argon2 hash.")
+    parser_argon2_verify.add_argument("password", nargs="?", help="Password to verify (prompts if omitted).")
+    parser_argon2_verify.add_argument("--hash", required=True, help="The Argon2 hash string to verify against.")
+
     # --- New 'password-lab' command ---
     parser_pwd = subparsers.add_parser(
         "password-lab",
@@ -24230,6 +24255,11 @@ async def main():
     if args.command in ["hashids-lab", "hashids"]:
         from shared.hashids_lab import run_hashids_lab_logic
         run_hashids_lab_logic(args)
+        return
+
+    if args.command in ["argon2-lab", "argon2"]:
+        from shared.argon2_lab import run_argon2_lab_logic
+        run_argon2_lab_logic(args)
         return
 
     if args.command in ["password-lab", "pwd-lab"]:

--- a/shared/argon2_lab.py
+++ b/shared/argon2_lab.py
@@ -1,0 +1,109 @@
+import argparse
+import sys
+import getpass
+
+try:
+    from argon2 import PasswordHasher
+    from argon2.exceptions import VerifyMismatchError
+    HAS_ARGON2 = True
+except ImportError:
+    HAS_ARGON2 = False
+
+class Argon2LabManager:
+    """Manages Argon2 password hashing and verification."""
+
+    def __init__(self):
+        if not HAS_ARGON2:
+            raise ImportError(
+                "argon2-cffi library not installed. "
+                "Please install it using 'pip install argon2-cffi'."
+            )
+
+    def hash_password(
+        self,
+        password: str,
+        time_cost: int = 3,
+        memory_cost: int = 65536,
+        parallelism: int = 4,
+        hash_len: int = 32
+    ) -> str:
+        """
+        Hashes a password using Argon2id.
+        """
+        ph = PasswordHasher(
+            time_cost=time_cost,
+            memory_cost=memory_cost,
+            parallelism=parallelism,
+            hash_len=hash_len
+        )
+        return ph.hash(password)
+
+    def verify_password(self, password: str, hash_str: str) -> bool:
+        """
+        Verifies a password against an Argon2 hash.
+        """
+        ph = PasswordHasher()
+        try:
+            return ph.verify(hash_str, password)
+        except VerifyMismatchError:
+            return False
+
+def run_argon2_lab_logic(args: argparse.Namespace) -> bool:
+    """CLI logic for Argon2 Lab."""
+    try:
+        manager = Argon2LabManager()
+    except ImportError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return False
+
+    if args.action == "hash":
+        password = args.password
+        if not password:
+            if not sys.stdin.isatty():
+                password = sys.stdin.read().strip()
+            else:
+                password = getpass.getpass("Enter password to hash: ")
+
+        if not password:
+            print("Error: Password is required.", file=sys.stderr)
+            return False
+
+        try:
+            hashed = manager.hash_password(
+                password=password,
+                time_cost=args.time_cost,
+                memory_cost=args.memory_cost,
+                parallelism=args.parallelism,
+                hash_len=args.hash_len
+            )
+            print(hashed)
+            return True
+        except Exception as e:
+            print(f"Error hashing password: {e}", file=sys.stderr)
+            return False
+
+    elif args.action == "verify":
+        password = args.password
+        if not password:
+            if not sys.stdin.isatty():
+                password = sys.stdin.read().strip()
+            else:
+                password = getpass.getpass("Enter password to verify: ")
+
+        if not password:
+            print("Error: Password is required.", file=sys.stderr)
+            return False
+
+        try:
+            is_valid = manager.verify_password(password, args.hash)
+            if is_valid:
+                print("✅ Password is valid.")
+                return True
+            else:
+                print("❌ Invalid password.")
+                return False
+        except Exception as e:
+            print(f"Error verifying password: {e}", file=sys.stderr)
+            return False
+
+    return False

--- a/tests/test_argon2_cli.py
+++ b/tests/test_argon2_cli.py
@@ -1,0 +1,69 @@
+import pytest
+import sys
+import argparse
+from io import StringIO
+from unittest.mock import patch
+
+pytest.importorskip("argon2")
+
+from shared.argon2_lab import run_argon2_lab_logic
+
+class TestArgon2Cli:
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_cli_hash(self, mock_stdout):
+        args = argparse.Namespace(
+            action="hash",
+            password="testpassword",
+            time_cost=2,
+            memory_cost=10240,
+            parallelism=2,
+            hash_len=16
+        )
+
+        result = run_argon2_lab_logic(args)
+        assert result is True
+        output = mock_stdout.getvalue().strip()
+        assert output.startswith("$argon2id$v=19$m=10240,t=2,p=2$")
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_cli_verify_success(self, mock_stdout):
+        # Generate a real hash first
+        args_hash = argparse.Namespace(
+            action="hash",
+            password="testpassword",
+            time_cost=2,
+            memory_cost=10240,
+            parallelism=2,
+            hash_len=16
+        )
+        with patch('sys.stdout', new_callable=StringIO) as mock_stdout_hash:
+            run_argon2_lab_logic(args_hash)
+            hash_str = mock_stdout_hash.getvalue().strip()
+
+        # Verify it
+        args_verify = argparse.Namespace(
+            action="verify",
+            password="testpassword",
+            hash=hash_str
+        )
+        result = run_argon2_lab_logic(args_verify)
+        assert result is True
+        output = mock_stdout.getvalue().strip()
+        assert "✅ Password is valid." in output
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_cli_verify_failure(self, mock_stdout):
+        # We need a valid argon2 hash to avoid exceptions during verify
+        # E.g. testpassword
+        hash_str = "$argon2id$v=19$m=10240,t=2,p=2$HkP9rQj/yF5z2/U9qL9Bjw$fB4r5bHq2p+rQ+9uXqY"
+
+        args = argparse.Namespace(
+            action="verify",
+            password="wrongpassword",
+            hash=hash_str
+        )
+
+        result = run_argon2_lab_logic(args)
+        assert result is False
+        output = mock_stdout.getvalue().strip()
+        assert "❌ Invalid password." in output

--- a/tests/test_argon2_lab.py
+++ b/tests/test_argon2_lab.py
@@ -1,0 +1,33 @@
+import pytest
+
+pytest.importorskip("argon2")
+
+from shared.argon2_lab import Argon2LabManager
+
+class TestArgon2LabManager:
+    def setup_method(self):
+        self.manager = Argon2LabManager()
+
+    def test_hash_password(self):
+        password = "mysecretpassword123!"
+        hashed = self.manager.hash_password(
+            password=password,
+            time_cost=2,
+            memory_cost=10240,
+            parallelism=2,
+            hash_len=16
+        )
+        assert hashed.startswith("$argon2id$v=19$m=10240,t=2,p=2$")
+
+    def test_verify_password_success(self):
+        password = "mysecretpassword123!"
+        hashed = self.manager.hash_password(password)
+        is_valid = self.manager.verify_password(password, hashed)
+        assert is_valid is True
+
+    def test_verify_password_failure(self):
+        password = "mysecretpassword123!"
+        wrong_password = "wrongpassword"
+        hashed = self.manager.hash_password(password)
+        is_valid = self.manager.verify_password(wrong_password, hashed)
+        assert is_valid is False


### PR DESCRIPTION
Adds a new `argon2-lab` CLI command to hash and verify passwords using the secure Argon2id algorithm. Implements `shared.argon2_lab.Argon2LabManager` that wraps `argon2-cffi`, with graceful fallback if the library is missing. Includes full unit and integration tests.

---
*PR created automatically by Jules for task [14213813697530269573](https://jules.google.com/task/14213813697530269573) started by @process-failed-successfully*