### PR TITLE
fix: Handle missing argon2-cffi dependency in Argon2LabTab

### DIFF
--- a/shared/tui_argon2.py
+++ b/shared/tui_argon2.py
@@ -10,9 +10,16 @@ class Argon2LabTab(Container):
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
-        self.manager = Argon2LabManager()
+        try:
+            self.manager = Argon2LabManager()
+        except ImportError:
+            self.manager = None
 
     def compose(self) -> ComposeResult:
+        if self.manager is None:
+            yield Label("argon2-cffi library not installed. Please install it using 'pip install argon2-cffi'.", classes="error-text")
+            return
+
         with Vertical():
             yield Label("[bold]Argon2 Lab[/bold]", classes="welcome-text")
 


### PR DESCRIPTION
Fixes the CI workflow "Robust CI" failure caused by `argon2-cffi` not being installed.
By gracefully catching the `ImportError` and rendering a warning label instead of standard UI components when the manager fails to load, the TUI application can continue to run and be tested safely without crashing entirely.

---
*PR created automatically by Jules for task [5999402468881155065](https://jules.google.com/task/5999402468881155065) started by @process-failed-successfully*