### PR TITLE
feat(hexdump-lab): Add TUI for hexdump-lab command

### DIFF
--- a/main.py
+++ b/main.py
@@ -16093,6 +16093,7 @@ def parse_args(argv=None):
     parser_hexdump.add_argument("--text", "-t", help="Text to dump.")
     parser_hexdump.add_argument("--offset", "-o", type=int, default=0, help="Starting byte offset.")
     parser_hexdump.add_argument("--length", "-l", type=int, default=-1, help="Number of bytes to read (-1 for all).")
+    parser_hexdump.add_argument("--tui", action="store_true", help="Launch the Hexdump Lab TUI.")
 
     # --- New 'filetype-lab' command ---
     parser_filetype = subparsers.add_parser(
@@ -24733,6 +24734,22 @@ async def main():
         return
 
     if args.command in ["hexdump-lab", "hexdump"]:
+        if getattr(args, "action", None) == "tui" or getattr(args, "tui", False):
+            from shared.tui import AgentTUI
+            print("Launching Hexdump Lab TUI...")
+            app = AgentTUI(project_dir=getattr(args, 'project_dir', Path(".")), start_tab="tab-hexdump")
+            import asyncio
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+            if loop and loop.is_running():
+                asyncio.ensure_future(app.run_async())
+            else:
+                app.run()
+                sys.exit(0)
+            return
+
         from shared.hexdump_lab import run_hexdump_lab_logic
         success = run_hexdump_lab_logic(args)
         if success:

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -111,6 +111,7 @@ from shared.tui_cheatsheet import CheatsheetTab
 from shared.tui_mac import MacLabTab
 from shared.tui_size import SizeLabTab
 from shared.tui_typegen import TypegenLabTab
+from shared.tui_hexdump import HexdumpLabTab
 from shared.tui_hash_validator import HashValidatorLabTab
 from shared.tui_snippets import SnippetsTab
 from shared.tui_pull_requests import PullRequestsTab
@@ -4908,6 +4909,8 @@ class AgentTUI(App):
                 yield HashValidatorLabTab()
             with TabPane("Size Lab", id="tab-size"):
                 yield SizeLabTab()
+            with TabPane("Hexdump Lab", id="tab-hexdump"):
+                yield HexdumpLabTab()
 
             with TabPane("Unicode Lab", id="tab-uni"):
                 yield UniLabTab()

--- a/shared/tui_hexdump.py
+++ b/shared/tui_hexdump.py
@@ -1,0 +1,104 @@
+import os
+from pathlib import Path
+from textual.app import ComposeResult
+from textual.containers import Horizontal, VerticalScroll, Vertical
+from textual.widgets import TabPane, Input, Button, Label, RichLog, RadioSet, RadioButton
+from textual import on, work
+from textual.message import Message
+
+from shared.hexdump_lab import HexdumpManager
+
+
+class HexdumpLabTab(TabPane):
+    """A TUI tab for Hexdump Lab."""
+
+    def __init__(self, id: str = "tab-hexdump", classes: str = ""):
+        super().__init__("Hexdump Lab", id=id, classes=classes)
+        self.manager = HexdumpManager()
+
+    def compose(self) -> ComposeResult:
+        with VerticalScroll():
+            yield Label("Generate Hex Dump", classes="section-header")
+
+            with Horizontal():
+                with RadioSet(id="hexdump-source-type"):
+                    yield RadioButton("Text Input", id="hexdump-type-text", value=True)
+                    yield RadioButton("File Path", id="hexdump-type-file")
+
+            yield Input(placeholder="Enter text or file path...", id="hexdump-input")
+
+            with Horizontal(classes="controls-row"):
+                yield Input(placeholder="Offset (e.g. 0)", value="0", id="hexdump-offset", type="integer", classes="number-input")
+                yield Input(placeholder="Length (-1 for all)", value="-1", id="hexdump-length", type="integer", classes="number-input")
+
+            with Horizontal(classes="controls-row"):
+                yield Button("Generate Dump", id="hexdump-generate-btn", variant="primary")
+                yield Button("Clear Output", id="hexdump-clear-btn", variant="error")
+
+            yield Label("Hex Dump Output:")
+            yield RichLog(id="hexdump-output", wrap=False, highlight=True, markup=True)
+
+    @on(Button.Pressed, "#hexdump-generate-btn")
+    def on_generate_pressed(self, event: Button.Pressed) -> None:
+        """Handle generate button press."""
+        input_widget = self.query_one("#hexdump-input", Input)
+        offset_widget = self.query_one("#hexdump-offset", Input)
+        length_widget = self.query_one("#hexdump-length", Input)
+        type_radio = self.query_one("#hexdump-source-type", RadioSet)
+        output_log = self.query_one("#hexdump-output", RichLog)
+
+        val = input_widget.value.strip()
+
+        try:
+            offset = int(offset_widget.value) if offset_widget.value else 0
+            length = int(length_widget.value) if length_widget.value else -1
+        except ValueError:
+            output_log.write("[bold red]Error: Offset and Length must be integers.[/bold red]")
+            return
+
+        if not val:
+             output_log.write("[bold red]Error: Input cannot be empty.[/bold red]")
+             return
+
+        data = b""
+        if type_radio.pressed_button and type_radio.pressed_button.id == "hexdump-type-file":
+             p = Path(val)
+             if not p.is_file():
+                  output_log.write(f"[bold red]Error: File '{val}' not found.[/bold red]")
+                  return
+             try:
+                 with open(p, "rb") as f:
+                     if offset > 0:
+                         f.seek(offset)
+                     if length >= 0:
+                         data = f.read(length)
+                     else:
+                         data = f.read()
+             except Exception as e:
+                 output_log.write(f"[bold red]Error reading file: {e}[/bold red]")
+                 return
+        else:
+             # Text mode
+             text_data = val.encode("utf-8")
+             start = max(0, offset)
+             if length >= 0:
+                  data = text_data[start:start + length]
+             else:
+                  data = text_data[start:]
+
+        try:
+            # Hexdump manager offset parameter is just for labeling rows
+            # We already truncated the data above correctly.
+            # But the label offset should match the actual file offset if requested.
+            result = self.manager.hexdump(data, offset=offset)
+            output_log.write(f"[bold green]--- Hex Dump ---[/bold green]")
+            output_log.write(result)
+        except Exception as e:
+            output_log.write(f"[bold red]Error generating hexdump: {e}[/bold red]")
+
+
+    @on(Button.Pressed, "#hexdump-clear-btn")
+    def on_clear_pressed(self, event: Button.Pressed) -> None:
+        """Handle clear button press."""
+        output_log = self.query_one("#hexdump-output", RichLog)
+        output_log.clear()

--- a/tests/test_tui_hexdump.py
+++ b/tests/test_tui_hexdump.py
@@ -51,7 +51,7 @@ class TestHexdumpLabTab(unittest.IsolatedAsyncioTestCase):
         # Default is text type radio button
 
         generate_btn = tab.query_one("#hexdump-generate-btn", Button)
-        await self.pilot.click(generate_btn.__class__)
+        await self.pilot.click("#hexdump-generate-btn")
 
         mock_hexdump.assert_called_once_with(b"test string", offset=0)
 

--- a/tests/test_tui_hexdump.py
+++ b/tests/test_tui_hexdump.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+try:
+    import textual
+    from textual.app import App
+    from textual.widgets import Input, Button, RichLog, RadioSet
+    from shared.tui_hexdump import HexdumpLabTab
+    TEXTUAL_AVAILABLE = True
+except ImportError:
+    TEXTUAL_AVAILABLE = False
+    App = object
+
+@unittest.skipIf(not TEXTUAL_AVAILABLE, "Textual not available")
+class TestHexdumpLabTab(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        class DummyApp(App):
+            def compose(self):
+                yield HexdumpLabTab()
+
+        self.app = DummyApp()
+        self._app_cm = self.app.run_test(headless=True, size=(100, 40))
+        self.pilot = await self._app_cm.__aenter__()
+
+    async def asyncTearDown(self):
+        await self._app_cm.__aexit__(None, None, None)
+
+    async def test_initial_render(self):
+        """Test the initial rendering of the tab."""
+        tab = self.app.query_one(HexdumpLabTab)
+        self.assertIsNotNone(tab)
+
+        input_widget = tab.query_one("#hexdump-input", Input)
+        self.assertEqual(input_widget.placeholder, "Enter text or file path...")
+
+        offset_widget = tab.query_one("#hexdump-offset", Input)
+        self.assertEqual(offset_widget.value, "0")
+
+        length_widget = tab.query_one("#hexdump-length", Input)
+        self.assertEqual(length_widget.value, "-1")
+
+    @patch("shared.tui_hexdump.HexdumpManager.hexdump")
+    async def test_generate_text_hexdump(self, mock_hexdump):
+        """Test generating hexdump from text input."""
+        mock_hexdump.return_value = "mock_hexdump_output"
+
+        tab = self.app.query_one(HexdumpLabTab)
+        input_widget = tab.query_one("#hexdump-input", Input)
+        input_widget.value = "test string"
+
+        # Default is text type radio button
+
+        generate_btn = tab.query_one("#hexdump-generate-btn", Button)
+        await self.pilot.click(generate_btn.__class__)
+
+        mock_hexdump.assert_called_once_with(b"test string", offset=0)
+
+        output_log = tab.query_one("#hexdump-output", RichLog)
+        lines = [line.text for line in output_log.lines]
+
+        self.assertTrue(any("--- Hex Dump ---" in line for line in lines))
+        self.assertTrue(any("mock_hexdump_output" in line for line in lines))
+
+    async def test_clear_output(self):
+        """Test clearing the output log."""
+        tab = self.app.query_one(HexdumpLabTab)
+        output_log = tab.query_one("#hexdump-output", RichLog)
+
+        output_log.write("some test data")
+
+        clear_btn = tab.query_one("#hexdump-clear-btn", Button)
+        await self.pilot.click("#hexdump-clear-btn")
+
+        self.assertEqual(len(output_log.lines), 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a TUI tab for the `hexdump-lab` command, allowing users to inspect binary data interactively.

---
*PR created automatically by Jules for task [5468820702202210123](https://jules.google.com/task/5468820702202210123) started by @process-failed-successfully*