### PR TITLE
fix: resolve test_vin_lab.py CI failures

### DIFF
--- a/shared/vin_lab.py
+++ b/shared/vin_lab.py
@@ -1,5 +1,6 @@
 import sys
-from typing import Dict, Any, Tuple
+from typing import Dict, Any
+
 
 class VinManager:
     """
@@ -137,6 +138,7 @@ class VinManager:
             "region": region,
             "is_valid": is_valid
         }
+
 
 def run_vin_lab_logic(args):
     """

--- a/tests/test_vin_lab.py
+++ b/tests/test_vin_lab.py
@@ -1,34 +1,45 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))  # noqa: E402
+
 import pytest
 from shared.vin_lab import VinManager
+
 
 @pytest.fixture
 def manager():
     return VinManager()
 
+
 def test_validate_valid_vin(manager):
     # A known valid VIN (e.g. a random real one)
-    assert manager.validate("1HGCM82633A004352") == True
+    assert manager.validate("1HGCM82633A004352") is True
+
 
 def test_validate_invalid_length(manager):
-    assert manager.validate("1HGCM82633") == False
+    assert manager.validate("1HGCM82633") is False
+
 
 def test_validate_invalid_chars(manager):
     # 'O' is invalid
-    assert manager.validate("1HGCM82633A00435O") == False
+    assert manager.validate("1HGCM82633A00435O") is False
     # 'I' is invalid
-    assert manager.validate("1HGCM82633A00435I") == False
+    assert manager.validate("1HGCM82633A00435I") is False
     # 'Q' is invalid
-    assert manager.validate("1HGCM82633A00435Q") == False
+    assert manager.validate("1HGCM82633A00435Q") is False
+
 
 def test_validate_invalid_checksum(manager):
     # Valid is 1HGCM82633A004352, so change one char to break checksum
-    assert manager.validate("1HGCM82633A004353") == False
+    assert manager.validate("1HGCM82633A004353") is False
+
 
 def test_decode_valid_vin(manager):
     decoded = manager.decode("1HGCM82633A004352")
 
     assert decoded["vin"] == "1HGCM82633A004352"
-    assert decoded["is_valid"] == True
+    assert decoded["is_valid"] is True
     assert decoded["wmi"] == "1HG"
     assert decoded["vds"] == "CM8263"
     assert decoded["vis"] == "3A004352"
@@ -38,13 +49,16 @@ def test_decode_valid_vin(manager):
     assert decoded["plant_code"] == "A"
     assert decoded["serial_number"] == "004352"
 
+
 def test_decode_invalid_length(manager):
     with pytest.raises(ValueError, match="Invalid VIN format or length."):
         manager.decode("1HGCM82633A0043")
 
+
 def test_guess_year_pre_2010(manager):
     # 'Y' = 2000, 7th char = '1' (digit -> pre-2010 cycle)
     assert manager._guess_year('Y', '1') == 2000
+
 
 def test_guess_year_post_2010(manager):
     # 'Y' = 2000, 7th char = 'A' (alpha -> post-2010 cycle)


### PR DESCRIPTION
Fixes the "Robust CI" failure introduced by the vin-lab feature addition.

Specifically:
- Adds `sys.path.insert` to `tests/test_vin_lab.py` to correctly resolve `shared` module imports when tests are run directly via pytest.
- Fixes several flake8 `E712` violations where booleans were compared with `==` instead of `is`.
- Fixes `E302` blank line styling issues in both test and shared files.
- Removes unused `Tuple` import in `shared/vin_lab.py` (`F401`).

---
*PR created automatically by Jules for task [18223928787655141084](https://jules.google.com/task/18223928787655141084) started by @process-failed-successfully*