### PR TITLE
feat: add support for UUID version 7 generation and inspection

### DIFF
--- a/main.py
+++ b/main.py
@@ -14759,7 +14759,7 @@ def parse_args(argv=None):
 
     # uuid generate
     parser_uuid_gen = uuid_subparsers.add_parser("generate", aliases=["gen"], help="Generate UUIDs.")
-    parser_uuid_gen.add_argument("--version", "-v", type=int, choices=[1, 3, 4, 5], default=4, help="UUID version (default: 4).")
+    parser_uuid_gen.add_argument("--version", "-v", type=int, choices=[1, 3, 4, 5, 7], default=4, help="UUID version (default: 4).")
     parser_uuid_gen.add_argument("--count", "-c", type=int, default=1, help="Number of UUIDs to generate.")
     parser_uuid_gen.add_argument("--namespace", "-ns", help="Namespace for v3/v5 (DNS, URL, OID, X500, or UUID).")
     parser_uuid_gen.add_argument("--name", "-n", help="Name for v3/v5.")

--- a/shared/tui_uuid.py
+++ b/shared/tui_uuid.py
@@ -23,7 +23,7 @@ class UuidLabTab(Container):
 
                         with Horizontal():
                             yield Label("Version:")
-                            yield Select.from_values([1, 3, 4, 5], id="select-uuid-version", value=4)
+                            yield Select.from_values([1, 3, 4, 5, 7], id="select-uuid-version", value=4)
                             yield Label("Count:")
                             yield Input(placeholder="1", id="input-uuid-count", type="integer", value="1")
 
@@ -128,6 +128,10 @@ class UuidLabTab(Container):
             log.write(f"Time: {info.get('timestamp_iso', info.get('time'))}")
             log.write(f"Node (MAC): {info.get('mac')}")
             log.write(f"Clock Seq: {info.get('clock_seq')}")
+        elif info.get("version") == 7:
+            log.write(f"\n[bold]v7 Specifics:[/bold]")
+            log.write(f"Time MS: {info.get('time_ms')} (Unix Epoch)")
+            log.write(f"Date: {info.get('timestamp_iso')}")
 
         log.write(f"\nURN: {info['urn']}")
 

--- a/shared/uuid_lab.py
+++ b/shared/uuid_lab.py
@@ -36,6 +36,19 @@ class UuidLabManager:
                 u = uuid.uuid4()
             elif version == 5:
                 u = uuid.uuid5(ns_uuid, name)
+            elif version == 7:
+                import time
+                import os
+                t_ms = int(time.time() * 1000)
+                t_bytes = t_ms.to_bytes(6, 'big')
+                rand = os.urandom(10)
+                b = bytearray(16)
+                b[0:6] = t_bytes
+                b[6] = 0x70 | (rand[0] & 0x0f)
+                b[7] = rand[1]
+                b[8] = 0x80 | (rand[2] & 0x3f)
+                b[9:] = rand[3:10]
+                u = uuid.UUID(bytes=bytes(b))
             else:
                 raise ValueError(f"Unsupported UUID version: {version}")
 
@@ -75,6 +88,16 @@ class UuidLabManager:
                 ts = (u.time - 0x01b21dd213814000) / 1e7
                 from datetime import datetime
                 info["timestamp_iso"] = datetime.fromtimestamp(ts).isoformat()
+            except Exception:
+                pass
+
+        elif u.version == 7:
+            # Time is 48-bit Unix Epoch in milliseconds
+            time_ms = int.from_bytes(u.bytes[:6], 'big')
+            info["time_ms"] = time_ms
+            try:
+                from datetime import datetime
+                info["timestamp_iso"] = datetime.fromtimestamp(time_ms / 1000.0).isoformat()
             except Exception:
                 pass
 
@@ -157,6 +180,11 @@ def run_uuid_lab_logic(args):
              print(f"  Clock:   {info['clock_seq']}")
              print(f"  Node:    {info['node']}")
              print(f"  MAC:     {info['mac']}")
+
+        elif info.get("version") == 7:
+             print(f"  Time MS: {info.get('time_ms')} (Unix Epoch)")
+             if "timestamp_iso" in info:
+                 print(f"  Date:    {info['timestamp_iso']}")
 
     elif args.action == "validate":
         if manager.validate(args.uuid):

--- a/tests/test_uuid_lab.py
+++ b/tests/test_uuid_lab.py
@@ -42,6 +42,14 @@ class TestUuidLabManager(unittest.TestCase):
         u2 = uuid.uuid5(uuid.NAMESPACE_DNS, name)
         self.assertEqual(str(u2), u)
 
+    def test_generate_v7(self):
+        results = self.manager.generate(version=7, count=5)
+        self.assertEqual(len(results), 5)
+        for u in results:
+            self.assertTrue(self.manager.validate(u))
+            obj = uuid.UUID(u)
+            self.assertEqual(obj.version, 7)
+
     def test_inspect_v1(self):
         u = uuid.uuid1()
         info = self.manager.inspect(str(u))
@@ -49,6 +57,14 @@ class TestUuidLabManager(unittest.TestCase):
         self.assertEqual(info["version"], 1)
         self.assertIn("time", info)
         self.assertIn("mac", info)
+        self.assertIn("timestamp_iso", info)
+
+    def test_inspect_v7(self):
+        u = self.manager.generate(version=7)[0]
+        info = self.manager.inspect(u)
+        self.assertTrue(info["valid"])
+        self.assertEqual(info["version"], 7)
+        self.assertIn("time_ms", info)
         self.assertIn("timestamp_iso", info)
 
     def test_inspect_invalid(self):


### PR DESCRIPTION
This PR introduces full support for generating and inspecting UUID version 7, as defined in RFC 9562. UUIDv7 provides time-ordered values with a millisecond precision timestamp, resolving issues with randomness-based UUIDv4 when used as primary keys in databases. The implementation works across the CLI and TUI lab views, and is fully covered by updated unit tests.

---
*PR created automatically by Jules for task [13753536878038199808](https://jules.google.com/task/13753536878038199808) started by @process-failed-successfully*