### PR TITLE
feat: Add GraphQL schema generation to Typegen Lab

### DIFF
--- a/main.py
+++ b/main.py
@@ -20271,7 +20271,7 @@ Examples:
     typegen_generate = typegen_subparsers.add_parser("generate", help="Generate types from JSON")
     typegen_generate.add_argument("--json", help="JSON string to convert")
     typegen_generate.add_argument("--file", "-f", help="Path to JSON file")
-    typegen_generate.add_argument("--lang", "-l", choices=["typescript", "go", "python", "rust", "zod"], default="typescript", help="Target language")
+    typegen_generate.add_argument("--lang", "-l", choices=["typescript", "go", "python", "rust", "zod", "graphql"], default="typescript", help="Target language")
     typegen_generate.add_argument("--name", "-n", default="Root", help="Name of the root struct/interface")
     typegen_generate.add_argument("--output", "-o", help="File to write generated types to")
 

--- a/shared/tui_typegen.py
+++ b/shared/tui_typegen.py
@@ -34,7 +34,7 @@ class TypegenLabTab(Container):
 
                 yield Label("Language:")
                 yield Select.from_values(
-                    ["typescript", "go", "python", "rust", "zod"],
+                    ["typescript", "go", "python", "rust", "zod", "graphql"],
                     id="typegen-lang", value="typescript"
                 )
 
@@ -87,7 +87,7 @@ class TypegenLabTab(Container):
                 prefix = "import { z } from \"zod\";\n\n"
 
             output.text = prefix + result
-            output.language = "typescript" if lang == "zod" else (lang if lang in ["typescript", "go", "python", "rust"] else None)
+            output.language = "typescript" if lang == "zod" else (lang if lang in ["typescript", "go", "python", "rust", "graphql"] else None)
             log.write("[bold green]✅ Types generated successfully[/bold green]")
         except Exception as e:
             log.write(f"[bold red]Unexpected Error: {e}[/bold red]")

--- a/shared/typegen_lab.py
+++ b/shared/typegen_lab.py
@@ -62,24 +62,26 @@ class TypegenManager:
             self._generate_rust(data, name)
         elif lang == "zod":
             self._generate_zod(data, name)
+        elif lang == "graphql":
+            self._generate_graphql(data, name)
         else:
             self.structs["Error"] = f"Unsupported language: {lang}"
 
     def _get_value_type(self, val: Any, key: str, lang: str) -> str:
         if val is None:
-            return "any" if lang == "typescript" else "interface{}" if lang == "go" else "Any" if lang == "python" else "z.any()" if lang == "zod" else "Option<serde_json::Value>"
+            return "any" if lang == "typescript" else "interface{}" if lang == "go" else "Any" if lang == "python" else "z.any()" if lang == "zod" else "String" if lang == "graphql" else "Option<serde_json::Value>"
 
         if isinstance(val, bool):
-            return "boolean" if lang == "typescript" else "bool" if lang == "go" else "bool" if lang == "python" else "z.boolean()" if lang == "zod" else "bool"
+            return "boolean" if lang == "typescript" else "bool" if lang == "go" else "bool" if lang == "python" else "z.boolean()" if lang == "zod" else "Boolean" if lang == "graphql" else "bool"
 
         if isinstance(val, int):
-            return "number" if lang == "typescript" else "int" if lang == "go" else "int" if lang == "python" else "z.number()" if lang == "zod" else "i64"
+            return "number" if lang == "typescript" else "int" if lang == "go" else "int" if lang == "python" else "z.number()" if lang == "zod" else "Int" if lang == "graphql" else "i64"
 
         if isinstance(val, float):
-            return "number" if lang == "typescript" else "float64" if lang == "go" else "float" if lang == "python" else "z.number()" if lang == "zod" else "f64"
+            return "number" if lang == "typescript" else "float64" if lang == "go" else "float" if lang == "python" else "z.number()" if lang == "zod" else "Float" if lang == "graphql" else "f64"
 
         if isinstance(val, str):
-            return "string" if lang == "typescript" else "string" if lang == "go" else "str" if lang == "python" else "z.string()" if lang == "zod" else "String"
+            return "string" if lang == "typescript" else "string" if lang == "go" else "str" if lang == "python" else "z.string()" if lang == "zod" else "String" if lang == "graphql" else "String"
 
         if isinstance(val, dict):
             nested_name = self._get_type_name(key)
@@ -88,7 +90,7 @@ class TypegenManager:
 
         if isinstance(val, list):
             if not val:
-                base = "any" if lang == "typescript" else "interface{}" if lang == "go" else "Any" if lang == "python" else "z.any()" if lang == "zod" else "serde_json::Value"
+                base = "any" if lang == "typescript" else "interface{}" if lang == "go" else "Any" if lang == "python" else "z.any()" if lang == "zod" else "String" if lang == "graphql" else "serde_json::Value"
             else:
                 base = self._get_value_type(val[0], key, lang)
 
@@ -100,10 +102,12 @@ class TypegenManager:
                 return f"List[{base}]"
             elif lang == "zod":
                 return f"z.array({base})"
+            elif lang == "graphql":
+                return f"[{base}]"
             elif lang == "rust":
                 return f"Vec<{base}>"
 
-        return "any" if lang == "typescript" else "interface{}" if lang == "go" else "Any" if lang == "python" else "z.any()" if lang == "zod" else "serde_json::Value"
+        return "any" if lang == "typescript" else "interface{}" if lang == "go" else "Any" if lang == "python" else "z.any()" if lang == "zod" else "String" if lang == "graphql" else "serde_json::Value"
 
     def _generate_typescript(self, data: Dict[str, Any], name: str):
         lines = [f"export interface {name} {{"]
@@ -158,6 +162,14 @@ class TypegenManager:
             lines.append(f"  {key}: {zod_type},")
         lines.append("});")
         lines.append(f"export type {name} = z.infer<typeof {name}Schema>;")
+        self.structs[name] = "\n".join(lines)
+
+    def _generate_graphql(self, data: Dict[str, Any], name: str):
+        lines = [f"type {name} {{"]
+        for key, val in data.items():
+            gql_type = self._get_value_type(val, key, "graphql")
+            lines.append(f"  {key}: {gql_type}")
+        lines.append("}")
         self.structs[name] = "\n".join(lines)
 
 

--- a/tests/test_typegen_lab.py
+++ b/tests/test_typegen_lab.py
@@ -66,6 +66,18 @@ class TestTypegenManager(unittest.TestCase):
         self.assertIn("name: z.string(),", result)
         self.assertIn("user: z.lazy(() => UserSchema),", result)
 
+    def test_generate_graphql(self):
+        json_str = '{"id": "abc", "count": 10, "isActive": true, "tags": ["admin"], "settings": {"theme": "dark"}}'
+        result = self.manager.generate(json_str, root_name="Response", lang="graphql")
+        self.assertIn("type Response {", result)
+        self.assertIn("id: String", result)
+        self.assertIn("count: Int", result)
+        self.assertIn("isActive: Boolean", result)
+        self.assertIn("tags: [String]", result)
+        self.assertIn("settings: Settings", result)
+        self.assertIn("type Settings {", result)
+        self.assertIn("theme: String", result)
+
     def test_generate_nested(self):
         json_str = '{"user": {"name": "test"}}'
         result = self.manager.generate(json_str, root_name="Root", lang="typescript")


### PR DESCRIPTION
Adds support for generating GraphQL schema definitions (`type`) from JSON input within the `typegen-lab` CLI command and TUI.

* Updated `shared/typegen_lab.py` to handle JSON primitives, lists, and nested objects mapping to GraphQL scalars (`Int`, `String`, `Boolean`, `Float`) and Object types.
* Updated `shared/tui_typegen.py` to include `graphql` in language options and correctly apply syntax highlighting.
* Updated `main.py` `--lang` choices for `typegen-lab` to accept `graphql`.
* Added unit test to verify GraphQL SDL generation.

---
*PR created automatically by Jules for task [13604731532940307140](https://jules.google.com/task/13604731532940307140) started by @process-failed-successfully*