### PR TITLE
fix(phonetic_lab): correct indentation causing CI failure

### DIFF
--- a/main.py
+++ b/main.py
@@ -25227,7 +25227,7 @@ async def main():
             from shared.phone_lab import run_phone_lab_logic
             run_phone_lab_logic(args)
         else:
-            import sys; sys.exit(0)
+            sys.exit(0)
         return
 
     if args.command in ["mac-lab", "mac"]:

--- a/shared/phonetic_lab.py
+++ b/shared/phonetic_lab.py
@@ -42,10 +42,10 @@ class PhoneticLabManager:
                 result.append(code)
 
             if code != '0':
-                 last_code = code
+                last_code = code
             else:
-                 # Vowel breaks the sequence
-                 last_code = '0'
+                # Vowel breaks the sequence
+                last_code = '0'
 
         # Pad with zeros if necessary
         while len(result) < 4:


### PR DESCRIPTION
Fixed 5-space indentation error in `shared/phonetic_lab.py` which was breaking CI linting.

---
*PR created automatically by Jules for task [17397453959140719157](https://jules.google.com/task/17397453959140719157) started by @process-failed-successfully*