### PR TITLE
feat: Add INI to JSON converter lab

### DIFF
--- a/main.py
+++ b/main.py
@@ -15949,6 +15949,17 @@ def parse_args(argv=None):
     parser_json2ini.add_argument("--output", "-o", help="Output file path.")
     parser_json2ini.add_argument("--tui", action="store_true", help="Launch JSON to INI Lab TUI.")
 
+    # --- New 'ini2json-lab' command ---
+    parser_ini2json = subparsers.add_parser(
+        "ini2json-lab",
+        aliases=["ini2json", "i2j"],
+        help="INI to JSON converter utilities."
+    )
+    parser_ini2json.add_argument("--file", "-f", help="Input INI file.")
+    parser_ini2json.add_argument("--text", "-t", help="Input INI text.")
+    parser_ini2json.add_argument("--output", "-o", help="Output file path.")
+    parser_ini2json.add_argument("--tui", action="store_true", help="Launch INI to JSON Lab TUI.")
+
     # --- New 'json2csv-lab' command ---
     parser_json2csv = subparsers.add_parser(
         "json2csv-lab",
@@ -24784,6 +24795,11 @@ async def main():
     if args.command in ["json2ini-lab", "json2ini", "j2i"]:
         from shared.json2ini_lab import run_json2ini_lab_logic
         run_json2ini_lab_logic(args)
+        return
+
+    if args.command in ["ini2json-lab", "ini2json", "i2j"]:
+        from shared.ini2json_lab import run_ini2json_lab_logic
+        run_ini2json_lab_logic(args)
         return
 
     if args.command in ["json2csv-lab", "j2c"]:

--- a/shared/ini2json_lab.py
+++ b/shared/ini2json_lab.py
@@ -1,0 +1,104 @@
+import configparser
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Union
+
+
+class Ini2JsonManager:
+    """Manages the conversion of INI data to JSON format."""
+
+    def __init__(self, project_dir: Path = None):
+        self.project_dir = project_dir
+
+    def convert(self, ini_data: str) -> str:
+        """Converts INI string data to a JSON string."""
+        config = configparser.ConfigParser()
+        # To prevent configparser from converting keys to lowercase:
+        config.optionxform = str
+
+        try:
+            config.read_string(ini_data)
+        except configparser.Error as e:
+            raise ValueError(f"Invalid INI string: {e}")
+
+        result: Dict[str, Any] = {}
+
+        # Default section
+        if config.defaults():
+            result["DEFAULT"] = dict(config.defaults())
+
+        for section in config.sections():
+            result[section] = {}
+            for key in config.options(section):
+                val = config.get(section, key)
+                val_lower = val.lower()
+                if val_lower == "true":
+                    result[section][key] = True
+                elif val_lower == "false":
+                    result[section][key] = False
+                else:
+                    try:
+                        # Try parsing as float first to handle decimals
+                        float_val = float(val)
+                        # If it's an integer (like 42.0 or -42), convert it to int
+                        if float_val.is_integer():
+                            result[section][key] = int(float_val)
+                        else:
+                            result[section][key] = float_val
+                    except ValueError:
+                        result[section][key] = val
+
+        return json.dumps(result, indent=2)
+
+
+def run_ini2json_lab_logic(args):
+    """CLI handler for INI to JSON conversion."""
+    manager = Ini2JsonManager(getattr(args, 'project_dir', None))
+
+    if getattr(args, "action", None) == "tui" or getattr(args, "tui", False):
+        from shared.tui import AgentTUI
+        print("Launching INI to JSON Lab TUI...")
+        app = AgentTUI(project_dir=getattr(args, 'project_dir', None), start_tab="tab-ini2json")
+        import asyncio
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop and loop.is_running():
+            asyncio.ensure_future(app.run_async())
+            return
+        else:
+            app.run()
+        sys.exit(0)
+
+    # CLI mode
+    try:
+        input_data = None
+        if hasattr(args, "file") and args.file:
+            input_path = Path(args.file)
+            if not input_path.exists():
+                print(f"Error: File '{args.file}' not found.", file=sys.stderr)
+                sys.exit(1)
+            input_data = input_path.read_text(encoding="utf-8")
+        elif hasattr(args, "text") and args.text:
+            input_data = args.text
+        elif not sys.stdin.isatty():
+            input_data = sys.stdin.read().strip()
+
+        if not input_data:
+            print("Error: No input provided. Provide --file, --text, or pass INI via stdin.", file=sys.stderr)
+            sys.exit(1)
+
+        json_output = manager.convert(input_data)
+
+        if hasattr(args, "output") and args.output:
+            output_path = Path(args.output)
+            output_path.write_text(json_output, encoding="utf-8")
+            print(f"✅ Converted JSON saved to {args.output}")
+        else:
+            print(json_output, end="")
+
+    except Exception as e:
+        print(f"Error during conversion: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -176,6 +176,7 @@ from shared.tui_toml import TomlLabTab
 from shared.tui_yaml import YamlLabTab
 from shared.tui_xml import XmlLabTab
 from shared.tui_template import TemplateLabTab
+from shared.tui_ini2json import Ini2JsonLabTab
 from shared.tui_hashids import HashidsLabTab
 from shared.tui_props import PropsLabTab
 from shared.tui_random import RandomLabTab
@@ -4716,6 +4717,8 @@ class AgentTUI(App):
 
             with TabPane("JSON to INI", id="tab-json2ini"):
                 yield Json2IniLabTab()
+            with TabPane("INI to JSON", id="tab-ini2json"):
+                yield Ini2JsonLabTab()
             with TabPane("JSON to TS", id="tab-json2ts"):
                 yield Json2TsLabTab()
             with TabPane("JSON to Go", id="tab-json2go"):

--- a/shared/tui_ini2json.py
+++ b/shared/tui_ini2json.py
@@ -1,0 +1,46 @@
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal, Vertical
+from textual.widgets import Label, TextArea, Button
+from textual import on
+
+from shared.ini2json_lab import Ini2JsonManager
+
+
+class Ini2JsonLabTab(Container):
+    """
+    INI to JSON conversion tab.
+    """
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.manager = Ini2JsonManager()
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label("[bold]INI to JSON Converter[/bold]", classes="welcome-text")
+
+            with Horizontal():
+                with Vertical(classes="stat-box"):
+                    yield Label("[bold]Input INI[/bold]")
+                    yield TextArea(id="ini2json-input")
+                    yield Button("Convert to JSON", id="btn-convert-ini2json", variant="primary")
+
+                with Vertical(classes="stat-box"):
+                    yield Label("[bold]Output JSON[/bold]")
+                    yield TextArea(id="ini2json-output", read_only=True)
+
+    @on(Button.Pressed, "#btn-convert-ini2json")
+    def on_convert(self) -> None:
+        ini_input = self.query_one("#ini2json-input", TextArea).text
+        output_area = self.query_one("#ini2json-output", TextArea)
+
+        if not ini_input.strip():
+            self.notify("Please enter INI to convert.", severity="warning")
+            return
+
+        try:
+            json_str = self.manager.convert(ini_input)
+            output_area.text = json_str
+            self.notify("Conversion successful.")
+        except Exception as e:
+            output_area.text = f"Error: {e}"
+            self.notify("Conversion failed.", severity="error")

--- a/tests/test_ini2json_lab.py
+++ b/tests/test_ini2json_lab.py
@@ -1,0 +1,64 @@
+import unittest
+import json
+from shared.ini2json_lab import Ini2JsonManager
+
+
+class TestIni2JsonManager(unittest.TestCase):
+    def setUp(self):
+        self.manager = Ini2JsonManager()
+
+    def test_convert_simple(self):
+        ini_data = """
+[Section1]
+key1 = value1
+key2 = true
+
+[Section2]
+num = 42
+float_val = 3.14
+"""
+        json_output = self.manager.convert(ini_data)
+        data = json.loads(json_output)
+
+        self.assertIn("Section1", data)
+        self.assertEqual(data["Section1"]["key1"], "value1")
+        self.assertTrue(data["Section1"]["key2"])
+
+        self.assertIn("Section2", data)
+        self.assertEqual(data["Section2"]["num"], 42)
+        self.assertEqual(data["Section2"]["float_val"], 3.14)
+
+    def test_convert_with_defaults(self):
+        ini_data = """
+[DEFAULT]
+global_key = global_val
+
+[App]
+app_key = app_val
+"""
+        json_output = self.manager.convert(ini_data)
+        data = json.loads(json_output)
+
+        self.assertIn("DEFAULT", data)
+        self.assertEqual(data["DEFAULT"]["global_key"], "global_val")
+
+        self.assertIn("App", data)
+        self.assertEqual(data["App"]["app_key"], "app_val")
+
+    def test_convert_empty(self):
+        ini_data = ""
+        json_output = self.manager.convert(ini_data)
+        data = json.loads(json_output)
+        self.assertEqual(data, {})
+
+    def test_invalid_ini(self):
+        ini_data = """
+[Section
+invalid format
+"""
+        with self.assertRaises(ValueError):
+            self.manager.convert(ini_data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tui_ini2json.py
+++ b/tests/test_tui_ini2json.py
@@ -1,0 +1,59 @@
+import pytest
+import os
+import sys
+
+try:
+    from textual.app import App
+    TEXTUAL_AVAILABLE = True
+except ImportError:
+    TEXTUAL_AVAILABLE = False
+    App = object
+
+if TEXTUAL_AVAILABLE:
+    from shared.tui_ini2json import Ini2JsonLabTab
+
+@pytest.mark.skipif(not TEXTUAL_AVAILABLE, reason="Textual is required")
+class DummyApp(App):
+    def compose(self):
+        yield Ini2JsonLabTab()
+
+@pytest.mark.skipif(not TEXTUAL_AVAILABLE, reason="Textual is required")
+@pytest.mark.asyncio
+async def test_ini2json_tui_basic():
+    app = DummyApp()
+    async with app.run_test(headless=True) as pilot:
+        # Check initial state
+        input_area = app.query_one("#ini2json-input")
+        output_area = app.query_one("#ini2json-output")
+        assert input_area.text == ""
+        assert output_area.text == ""
+
+        # Input INI
+        input_area.text = "[Section]\nkey=value"
+
+        # Click convert
+        await pilot.click("#btn-convert-ini2json")
+        await pilot.pause(0.1)
+
+        # Output should contain the converted JSON
+        assert '"Section"' in output_area.text
+        assert '"key"' in output_area.text
+        assert '"value"' in output_area.text
+
+@pytest.mark.skipif(not TEXTUAL_AVAILABLE, reason="Textual is required")
+@pytest.mark.asyncio
+async def test_ini2json_tui_invalid():
+    app = DummyApp()
+    async with app.run_test(headless=True) as pilot:
+        input_area = app.query_one("#ini2json-input")
+        output_area = app.query_one("#ini2json-output")
+
+        # Input Invalid INI
+        input_area.text = "[Section\nbad_format"
+
+        # Click convert
+        await pilot.click("#btn-convert-ini2json")
+        await pilot.pause(0.1)
+
+        # Output should display error message
+        assert "Error:" in output_area.text


### PR DESCRIPTION
This PR implements the requested high-value feature by adding an `ini2json-lab` to parse INI configurations and convert them back into JSON. This completes the loop with the existing `json2ini-lab`, filling a notable usability gap.

Features:
- `Ini2JsonManager`: Robustly parses INI and properly infers booleans, floats, and integers (including negatives).
- `main.py`: Fully integrated CLI endpoint under `ini2json-lab`, `--file`, `--text`, and `--tui`.
- `tui.py`: Registered as a Textual layout tab.
- Added test coverage in both `tests/test_ini2json_lab.py` and `tests/test_tui_ini2json.py`.

---
*PR created automatically by Jules for task [17517562469798016340](https://jules.google.com/task/17517562469798016340) started by @process-failed-successfully*