### PR TITLE
feat: add DidYouMeanArgumentParser for command suggestions

### DIFF
--- a/main.py
+++ b/main.py
@@ -9778,8 +9778,31 @@ def run_config(args):
     return 0
 
 
+import difflib
+
+
+class DidYouMeanArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        if "invalid choice:" in message and "(choose from" in message:
+            import re
+            match = re.search(r"invalid choice: '([^']+)' \(choose from (.+)\)", message)
+            if match:
+                invalid_choice = match.group(1)
+                choices_str = match.group(2)
+                choices = [c.strip("' ") for c in choices_str.split(',')]
+
+                matches = difflib.get_close_matches(invalid_choice, choices, n=3, cutoff=0.5)
+
+                if matches:
+                    suggestions = ", ".join([f"'{m}'" for m in matches])
+                    message = f"{message}\n\nDid you mean: {suggestions}?"
+
+        self.print_usage(sys.stderr)
+        args = {'prog': self.prog, 'message': message}
+        self.exit(2, ('%(prog)s: error: %(message)s\n') % args)
+
 def parse_args(argv=None):
-    parser = argparse.ArgumentParser(description="Autonomous Coding Agent")
+    parser = DidYouMeanArgumentParser(description="Autonomous Coding Agent")
 
     # Core Configuration
     core_group = parser.add_argument_group("Core Configuration")

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -1,0 +1,46 @@
+import subprocess
+import sys
+from pathlib import Path
+
+def test_did_you_mean_suggestion():
+    """
+    Test that running main.py with an invalid command suggests closely matching valid commands.
+    """
+    root_dir = Path(__file__).parent.parent
+    main_script = root_dir / "main.py"
+
+    # Run with an invalid command that is close to 'json'
+    result = subprocess.run(
+        ["python3", str(main_script), "jsno"],
+        capture_output=True,
+        text=True
+    )
+
+    assert result.returncode == 2
+
+    # Standard argparse output should be there
+    assert "invalid choice: 'jsno'" in result.stderr
+
+    # Our new DidYouMean suggestion should be there
+    assert "Did you mean:" in result.stderr
+    assert "'json'" in result.stderr
+
+def test_did_you_mean_no_suggestion():
+    """
+    Test that completely bogus commands don't crash and just fall back to no suggestions.
+    """
+    root_dir = Path(__file__).parent.parent
+    main_script = root_dir / "main.py"
+
+    # Run with a command that has no close matches
+    result = subprocess.run(
+        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
+        capture_output=True,
+        text=True
+    )
+
+    assert result.returncode == 2
+    assert "invalid choice: 'xyz123thisisnotacommandatall'" in result.stderr
+
+    # There shouldn't be a suggestion for something completely random
+    assert "Did you mean:" not in result.stderr


### PR DESCRIPTION
This PR introduces a highly valuable usability improvement for the CLI. When a user mistypes a command (e.g. `jsno` instead of `json`), it intercepts the standard `argparse` "invalid choice" error and suggests closely matching available commands using "Did you mean: ...?". With over 800 subcommands, this significantly improves the developer experience. Unit tests have been added to verify both suggestion logic and fallback behavior.

---
*PR created automatically by Jules for task [6649879364106387215](https://jules.google.com/task/6649879364106387215) started by @process-failed-successfully*