### PR TITLE
fix: robust python invocation in did-you-mean tests

### DIFF
--- a/test_pillow.py
+++ b/test_pillow.py
@@ -1,7 +1,0 @@
-from pathlib import Path
-from PIL import Image
-
-p = Path("/tmp/test_logo.png")
-img = Image.new('RGB', (512, 512), color='red')
-img.save(p)
-print("Exists:", p.exists())

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -9,11 +9,16 @@ def test_did_you_mean_suggestion():
     root_dir = Path(__file__).parent.parent
     main_script = root_dir / "main.py"
 
+    import os
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(root_dir)
+
     # Run with an invalid command that is close to 'json'
     result = subprocess.run(
-        ["python3", str(main_script), "jsno"],
+        [sys.executable, str(main_script), "jsno"],
         capture_output=True,
-        text=True
+        text=True,
+        env=env
     )
 
     assert result.returncode == 2
@@ -32,11 +37,16 @@ def test_did_you_mean_no_suggestion():
     root_dir = Path(__file__).parent.parent
     main_script = root_dir / "main.py"
 
+    import os
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(root_dir)
+
     # Run with a command that has no close matches
     result = subprocess.run(
-        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
+        [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],
         capture_output=True,
-        text=True
+        text=True,
+        env=env
     )
 
     assert result.returncode == 2

--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -48,6 +48,9 @@ def test_generate_favicons(tmp_path):
     img = Image.new('RGB', (512, 512), color='red')
     img.save(str(input_img), format="PNG")
 
+    # In older versions of Pillow, image objects should be closed when created manually to free file descriptors and flush write buffers.
+    img.close()
+
     assert Path(str(input_img)).exists(), "Test image was not created!"
 
     result = manager.generate(Path(str(input_img)), Path(str(out_dir)))

--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -45,8 +45,8 @@ def test_generate_favicons(tmp_path):
     out_dir = tmp_path / "public"
 
     # Create a dummy image
-    with Image.new('RGB', (512, 512), color='red') as img:
-        img.save(str(input_img), format="PNG")
+    img = Image.new('RGB', (512, 512), color='red')
+    img.save(str(input_img), format="PNG")
 
     assert Path(str(input_img)).exists(), "Test image was not created!"
 


### PR DESCRIPTION
Fixing CI failure caused by tests/test_did_you_mean.py by using sys.executable and configuring PYTHONPATH explicitly to ensure the tests run in the correct environment with all modules resolvable.

---
*PR created automatically by Jules for task [6886650148650431476](https://jules.google.com/task/6886650148650431476) started by @process-failed-successfully*