### PR TITLE
fix: resize image before saving as ICO in FaviconManager

### DIFF
--- a/shared/favicon_lab.py
+++ b/shared/favicon_lab.py
@@ -76,7 +76,16 @@ class FaviconManager:
                     # Creating a copy of the image and using it avoids mutating the original
                     # image object inside PIL when saving with the sizes parameter
                     img_ico = img.copy()
+
+                    # Pillow saving as ICO with sizes requires the image to be at least the size
+                    # of the largest icon to be properly generated, and can sometimes result in
+                    # corrupted or empty files if the original is very small (like 1x1 in tests).
+                    img_ico = img_ico.resize((48, 48), resample=Image.Resampling.LANCZOS)
                     img_ico.save(ico_path, format="ICO", sizes=icon_sizes)
+
+                    # Verify the file is actually a valid image
+                    with Image.open(ico_path) as _:
+                        pass
                 except Exception as ico_e:
                     # Fallback if sizes param fails entirely on certain Pillow versions
                     img_small = img.resize((32, 32), resample=Image.Resampling.LANCZOS)

--- a/test_pillow.py
+++ b/test_pillow.py
@@ -1,7 +1,0 @@
-from pathlib import Path
-from PIL import Image
-
-p = Path("/tmp/test_logo.png")
-img = Image.new('RGB', (512, 512), color='red')
-img.save(p)
-print("Exists:", p.exists())


### PR DESCRIPTION
Fixes a bug where Pillow `12.2.0` could fail to properly save an ICO file with multiple sizes if the original image was smaller than the requested icon sizes (like a 1x1 image used in testing). The image is now explicitly resized to `(48, 48)` before saving the ICO to prevent silent failures and ensure valid file generation. Also verified the output via `Image.open`.

---
*PR created automatically by Jules for task [2349949246845780825](https://jules.google.com/task/2349949246845780825) started by @process-failed-successfully*