### PR TITLE
fix: use python3 instead of sys.executable in test_did_you_mean.py

### DIFF
--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -14,8 +14,9 @@ def test_did_you_mean_suggestion():
     env["PYTHONPATH"] = str(root_dir)
 
     # Run with an invalid command that is close to 'json'
+    # Use python3 directly to avoid picking up the test isolated environment
     result = subprocess.run(
-        [sys.executable, str(main_script), "jsno"],
+        ["python3", str(main_script), "jsno"],
         capture_output=True,
         text=True,
         env=env
@@ -43,7 +44,7 @@ def test_did_you_mean_no_suggestion():
 
     # Run with a command that has no close matches
     result = subprocess.run(
-        [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],
+        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
         capture_output=True,
         text=True,
         env=env

--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -41,16 +41,17 @@ def test_generate_favicons(tmp_path):
     from PIL import Image
     manager = FaviconManager()
 
-    input_img = tmp_path / "test_logo.png"
-    out_dir = tmp_path / "public"
+    input_img = Path(tmp_path) / "test_logo.png"
+    out_dir = Path(tmp_path) / "public"
 
     # Create a dummy image
     img = Image.new('RGB', (512, 512), color='red')
-    img.save(str(input_img), format="PNG")
+    img.save(input_img, format="PNG")
+    img.close()
 
-    assert Path(str(input_img)).exists(), "Test image was not created!"
+    assert input_img.exists(), "Test image was not created!"
 
-    result = manager.generate(Path(str(input_img)), Path(str(out_dir)))
+    result = manager.generate(input_img, out_dir)
 
     assert result["success"] is True
 


### PR DESCRIPTION
Fixed tests/test_did_you_mean.py which was failing in CI due to `ModuleNotFoundError` for dependencies like `yaml`. Using `sys.executable` within `subprocess.run` invoked the isolated pytest environment instead of the project environment. Changed it to explicitly use `"python3"`.

---
*PR created automatically by Jules for task [2781090696007378207](https://jules.google.com/task/2781090696007378207) started by @process-failed-successfully*