### PR TITLE
fix: Use python3 over sys.executable in tests

### DIFF
--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -15,7 +15,7 @@ def test_did_you_mean_suggestion():
     env["PYTHONPATH"] = str(root_dir)
 
     result = subprocess.run(
-        [sys.executable, str(main_script), "jsno"],
+        ["python3", str(main_script), "jsno"],
         capture_output=True,
         text=True,
         env=env
@@ -42,7 +42,7 @@ def test_did_you_mean_no_suggestion():
     env["PYTHONPATH"] = str(root_dir)
 
     result = subprocess.run(
-        [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],
+        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
         capture_output=True,
         text=True,
         env=env


### PR DESCRIPTION
Fix test runner using isolated env instead of project env.

---
*PR created automatically by Jules for task [3579962623628789312](https://jules.google.com/task/3579962623628789312) started by @process-failed-successfully*