### PR TITLE
fix: resolve Pillow ICO format issues and fix favicon CI test failures

### DIFF
--- a/shared/favicon_lab.py
+++ b/shared/favicon_lab.py
@@ -49,7 +49,9 @@ class FaviconManager:
                 # Generate favicon.ico (multi-resolution: 16x16, 32x32, 48x48)
                 ico_path = output_dir / "favicon.ico"
                 icon_sizes = [(16, 16), (32, 32), (48, 48)]
-                img.save(ico_path, format="ICO", sizes=icon_sizes)
+                img_ico = img.copy()
+                img_ico = img_ico.resize((48, 48), resample=Image.Resampling.LANCZOS)
+                img_ico.save(ico_path, format="ICO", sizes=icon_sizes)
                 generated_files.append(str(ico_path))
 
                 # Generate Apple Touch Icon (180x180)

--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -47,6 +47,7 @@ def test_generate_favicons(tmp_path):
     # Create a dummy image
     img = Image.new('RGB', (512, 512), color='red')
     img.save(str(input_img), format="PNG")
+    img.close()
 
     assert input_img.is_file(), "Test image was not created!"
 

--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -46,23 +46,22 @@ def test_generate_favicons(tmp_path):
 
     # Create a dummy image
     img = Image.new('RGB', (512, 512), color='red')
-    img.save(input_img, format="PNG")
-    img.close()
+    img.save(str(input_img), format="PNG")
 
-    assert input_img.exists(), "Test image was not created!"
+    assert input_img.is_file(), "Test image was not created!"
 
     result = manager.generate(input_img, out_dir)
 
     assert result["success"] is True
 
     # Verify expected files exist
-    assert (out_dir / "favicon.ico").exists()
-    assert (out_dir / "apple-touch-icon.png").exists()
-    assert (out_dir / "favicon-32x32.png").exists()
-    assert (out_dir / "favicon-16x16.png").exists()
-    assert (out_dir / "android-chrome-192x192.png").exists()
-    assert (out_dir / "android-chrome-512x512.png").exists()
-    assert (out_dir / "site.webmanifest").exists()
+    assert (out_dir / "favicon.ico").is_file()
+    assert (out_dir / "apple-touch-icon.png").is_file()
+    assert (out_dir / "favicon-32x32.png").is_file()
+    assert (out_dir / "favicon-16x16.png").is_file()
+    assert (out_dir / "android-chrome-192x192.png").is_file()
+    assert (out_dir / "android-chrome-512x512.png").is_file()
+    assert (out_dir / "site.webmanifest").is_file()
 
     # Verify site.webmanifest contents
     with open(out_dir / "site.webmanifest", "r") as f:


### PR DESCRIPTION
This commit fixes test failures and generation bugs in the favicon lab.

- Modifies `shared/favicon_lab.py` to ensure that standard icons like `favicon.ico` are created from a copied image resized accurately to the largest required size (`48x48`), solving silent corruption issues.
- Modifies `tests/test_favicon_lab.py` by removing an explicit close on PIL Images before assertions.
- Standardizes assertion checks in the testing framework to use `.is_file()` over `.exists()`.
- Added string casting explicitly to paths supplied to Pillow's save parameter to ensure CI test runner backwards compatibility.

---
*PR created automatically by Jules for task [1479651982697683169](https://jules.google.com/task/1479651982697683169) started by @process-failed-successfully*