### PR TITLE
test: use sys.executable in test_did_you_mean.py

### DIFF
--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -16,7 +16,7 @@ def test_did_you_mean_suggestion():
 
     # Run with an invalid command that is close to 'json'
     result = subprocess.run(
-        ["python3", str(main_script), "jsno"],
+        [sys.executable, str(main_script), "jsno"],
         capture_output=True,
         text=True,
         env=env
@@ -44,7 +44,7 @@ def test_did_you_mean_no_suggestion():
 
     # Run with a command that has no close matches
     result = subprocess.run(
-        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
+        [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],
         capture_output=True,
         text=True,
         env=env

--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -45,8 +45,9 @@ def test_generate_favicons(tmp_path):
     out_dir = tmp_path / "public"
 
     # Create a dummy image
-    img = Image.new('RGB', (512, 512), color='red')
+    img = Image.new('RGB', (512, 512), color=(255, 0, 0))
     img.save(str(input_img), format="PNG")
+    img.close()
     assert Path(str(input_img)).is_file(), "Test image was not created!"
 
     result = manager.generate(Path(str(input_img)), Path(str(out_dir)))


### PR DESCRIPTION
Use `sys.executable` instead of `"python3"` in `subprocess.run` within `tests/test_did_you_mean.py` to ensure the correct python environment is used during testing.

---
*PR created automatically by Jules for task [1699363254276454233](https://jules.google.com/task/1699363254276454233) started by @process-failed-successfully*