### PR TITLE
fix: update test_did_you_mean to safely use sys.executable and PYTHONPATH

### DIFF
--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import os
 from pathlib import Path
 
 def test_did_you_mean_suggestion():
@@ -10,9 +11,16 @@ def test_did_you_mean_suggestion():
     main_script = root_dir / "main.py"
 
     # Run with an invalid command that is close to 'json'
+    env = os.environ.copy()
+    if "PYTHONPATH" in env:
+        env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = str(root_dir)
+
     result = subprocess.run(
-        ["python3", str(main_script), "jsno"],
+        [sys.executable, str(main_script), "jsno"],
         capture_output=True,
+        env=env,
         text=True
     )
 
@@ -33,9 +41,16 @@ def test_did_you_mean_no_suggestion():
     main_script = root_dir / "main.py"
 
     # Run with a command that has no close matches
+    env = os.environ.copy()
+    if "PYTHONPATH" in env:
+        env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = str(root_dir)
+
     result = subprocess.run(
-        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
+        [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],
         capture_output=True,
+        env=env,
         text=True
     )
 

--- a/tests/test_favicon.py
+++ b/tests/test_favicon.py
@@ -13,7 +13,7 @@ def dummy_image(temp_dir):
     img_path = temp_dir / "logo.png"
     # Create a 512x512 dummy image
     img = Image.new("RGBA", (512, 512), color="red")
-    img.save(img_path)
+    img.save(str(img_path))
     return img_path
 
 def test_generate_favicons_success(temp_dir, dummy_image):

--- a/tests/test_tui_favicon.py
+++ b/tests/test_tui_favicon.py
@@ -17,7 +17,7 @@ except ImportError:
 def dummy_image(tmp_path):
     img_path = tmp_path / "test_logo.png"
     img = Image.new("RGBA", (512, 512), color="blue")
-    img.save(img_path)
+    img.save(str(img_path))
     return img_path
 
 


### PR DESCRIPTION
The CI pipeline was failing because `test_did_you_mean.py` was trying to execute `"python3"` directly, which fails or picks the wrong interpreter in isolated testing environments like `tox`. Additionally, tests could fail if `PYTHONPATH` was not correctly established for subprocess execution.

This fix:
1. Replaces `"python3"` with `sys.executable` to guarantee the test process uses the same isolated interpreter as `pytest`.
2. Explicitly sets `PYTHONPATH` using `os.environ.copy()`. If `PYTHONPATH` is already present in the environment, the project root is safely prepended using `os.pathsep` rather than overwriting it destructively.

---
*PR created automatically by Jules for task [14609435935207025584](https://jules.google.com/task/14609435935207025584) started by @process-failed-successfully*