### PR TITLE
test(did_you_mean): safely append root_dir to PYTHONPATH

### DIFF
--- a/fix_test_favicon.py
+++ b/fix_test_favicon.py
@@ -1,0 +1,8 @@
+from PIL import Image
+try:
+    from shared.favicon_lab import FaviconManager
+    HAS_FAVICON_DEPS = True
+except ImportError as e:
+    print(f"Error importing FaviconManager: {e}")
+    HAS_FAVICON_DEPS = False
+print(f"HAS_FAVICON_DEPS: {HAS_FAVICON_DEPS}")

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -12,7 +12,10 @@ def test_did_you_mean_suggestion():
 
     # Run with an invalid command that is close to 'json'
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(root_dir)
+    if "PYTHONPATH" in env:
+        env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = str(root_dir)
 
     result = subprocess.run(
         [sys.executable, str(main_script), "jsno"],
@@ -39,7 +42,10 @@ def test_did_you_mean_no_suggestion():
 
     # Run with a command that has no close matches
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(root_dir)
+    if "PYTHONPATH" in env:
+        env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = str(root_dir)
 
     result = subprocess.run(
         [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],


### PR DESCRIPTION
Update tests/test_did_you_mean.py to safely append `root_dir` to `PYTHONPATH` using `os.pathsep` rather than overwriting it destructively. This ensures that the environment variable preserves the paths set by the CI or the user and only pre-pends the project root.

---
*PR created automatically by Jules for task [2380459350886028407](https://jules.google.com/task/2380459350886028407) started by @process-failed-successfully*