### PR TITLE
Fix CI test failures for DidYouMeanArgumentParser

### DIFF
--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import os
 from pathlib import Path
 
 def test_did_you_mean_suggestion():
@@ -9,11 +10,15 @@ def test_did_you_mean_suggestion():
     root_dir = Path(__file__).parent.parent
     main_script = root_dir / "main.py"
 
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(root_dir)
+
     # Run with an invalid command that is close to 'json'
     result = subprocess.run(
-        ["python3", str(main_script), "jsno"],
+        [sys.executable, str(main_script), "jsno"],
         capture_output=True,
-        text=True
+        text=True,
+        env=env
     )
 
     assert result.returncode == 2
@@ -32,11 +37,15 @@ def test_did_you_mean_no_suggestion():
     root_dir = Path(__file__).parent.parent
     main_script = root_dir / "main.py"
 
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(root_dir)
+
     # Run with a command that has no close matches
     result = subprocess.run(
-        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
+        [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],
         capture_output=True,
-        text=True
+        text=True,
+        env=env
     )
 
     assert result.returncode == 2


### PR DESCRIPTION
The `DidYouMeanArgumentParser` tests were failing in CI because `subprocess.run` was invoking the system `python3` command without the project dependencies or proper Python path, leading to `ModuleNotFoundError` for internal modules like `yaml`.

This commit changes the test to use `sys.executable` to guarantee the pytest environment's Python is used, and securely passes the project root via the `PYTHONPATH` environment variable.

---
*PR created automatically by Jules for task [9872794846520315134](https://jules.google.com/task/9872794846520315134) started by @process-failed-successfully*