### PR TITLE
fix: resolve CI failure in did-you-mean tests and lint issues

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,6 +98,7 @@ from shared.sqlformat_lab import run_sqlformat_lab_logic
 from shared.json_lab import run_json_lab_logic
 from shared.yaml_lab import run_yaml_lab_logic
 from shared.yaml2json_lab import run_yaml2json_lab_logic
+import difflib
 from shared.yaml2csv_lab import run_yaml2csv_lab_logic
 from shared.xml2csv_lab import run_xml2csv_lab_logic
 from shared.toml2csv_lab import run_toml2csv_lab_logic
@@ -9778,9 +9779,6 @@ def run_config(args):
     return 0
 
 
-import difflib
-
-
 class DidYouMeanArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         if "invalid choice:" in message and "(choose from" in message:
@@ -9800,6 +9798,7 @@ class DidYouMeanArgumentParser(argparse.ArgumentParser):
         self.print_usage(sys.stderr)
         args = {'prog': self.prog, 'message': message}
         self.exit(2, ('%(prog)s: error: %(message)s\n') % args)
+
 
 def parse_args(argv=None):
     parser = DidYouMeanArgumentParser(description="Autonomous Coding Agent")

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -3,6 +3,7 @@ import sys
 import os
 from pathlib import Path
 
+
 def test_did_you_mean_suggestion():
     """
     Test that running main.py with an invalid command suggests closely matching valid commands.
@@ -12,7 +13,7 @@ def test_did_you_mean_suggestion():
 
     # Run with an invalid command that is close to 'json'
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(root_dir)
+    env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{env.get('PYTHONPATH', '')}"
 
     result = subprocess.run(
         [sys.executable, str(main_script), "jsno"],
@@ -30,6 +31,7 @@ def test_did_you_mean_suggestion():
     assert "Did you mean:" in result.stderr
     assert "'json'" in result.stderr
 
+
 def test_did_you_mean_no_suggestion():
     """
     Test that completely bogus commands don't crash and just fall back to no suggestions.
@@ -39,7 +41,7 @@ def test_did_you_mean_no_suggestion():
 
     # Run with a command that has no close matches
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(root_dir)
+    env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{env.get('PYTHONPATH', '')}"
 
     result = subprocess.run(
         [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],


### PR DESCRIPTION
Fix destructive PYTHONPATH overwrite in tests causing ModuleNotFoundError and fix E402/E302 PEP 8 violations in main.py.

---
*PR created automatically by Jules for task [7112907840939805539](https://jules.google.com/task/7112907840939805539) started by @process-failed-successfully*