### PR TITLE
fix: use sys.executable in DidYouMeanArgumentParser test and update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ dependencies = [
     "jq>=1.11.0",
     "mnemonic>=0.21",
     "faker>=24.0.0",
+    "jsonpath-ng>=1.6.1",
+    "tiktoken>=0.7.0",
 ]
 requires-python = ">=3.11"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,6 @@ dependencies = [
     "jq>=1.11.0",
     "mnemonic>=0.21",
     "faker>=24.0.0",
-    "jsonpath-ng>=1.6.1",
-    "tiktoken>=0.7.0",
-    "pytest-asyncio>=0.23.0",
 ]
 requires-python = ">=3.11"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dependencies = [
     "faker>=24.0.0",
     "jsonpath-ng>=1.6.1",
     "tiktoken>=0.7.0",
+    "pytest-asyncio>=0.23.0",
 ]
 requires-python = ">=3.11"
 

--- a/shared/favicon_lab.py
+++ b/shared/favicon_lab.py
@@ -49,7 +49,8 @@ class FaviconManager:
                 # Generate Apple Touch Icon (180x180)
                 apple_path = output_dir / "apple-touch-icon.png"
                 img_apple = img.resize((180, 180), resample=Image.Resampling.LANCZOS)
-                img_apple.save(apple_path, format="PNG")
+                with open(str(apple_path), "wb") as f:
+                    img_apple.save(f, format="PNG")
                 generated_files.append(str(apple_path))
 
                 # Generate standard size PNGs (32x32, 16x16)
@@ -57,7 +58,8 @@ class FaviconManager:
                 for size in png_sizes:
                     png_path = output_dir / f"favicon-{size[0]}x{size[1]}.png"
                     img_png = img.resize(size, resample=Image.Resampling.LANCZOS)
-                    img_png.save(png_path, format="PNG")
+                    with open(str(png_path), "wb") as f:
+                        img_png.save(f, format="PNG")
                     generated_files.append(str(png_path))
 
                 # Generate Android Chrome Icons
@@ -65,7 +67,8 @@ class FaviconManager:
                 for size in android_sizes:
                     android_path = output_dir / f"android-chrome-{size[0]}x{size[1]}.png"
                     img_android = img.resize(size, resample=Image.Resampling.LANCZOS)
-                    img_android.save(android_path, format="PNG")
+                    with open(str(android_path), "wb") as f:
+                        img_android.save(f, format="PNG")
                     generated_files.append(str(android_path))
 
                 # Generate favicon.ico (multi-resolution: 16x16, 32x32, 48x48)
@@ -81,7 +84,7 @@ class FaviconManager:
                     # of the largest icon to be properly generated, and can sometimes result in
                     # corrupted or empty files if the original is very small (like 1x1 in tests).
                     img_ico = img_ico.resize((48, 48), resample=Image.Resampling.LANCZOS)
-                    with open(ico_path, "wb") as f:
+                    with open(str(ico_path), "wb") as f:
                         img_ico.save(f, format="ICO", sizes=icon_sizes)
 
                     # Verify the file is actually a valid image
@@ -90,7 +93,7 @@ class FaviconManager:
                 except Exception as ico_e:
                     # Fallback if sizes param fails entirely on certain Pillow versions
                     img_small = img.resize((32, 32), resample=Image.Resampling.LANCZOS)
-                    with open(ico_path, "wb") as f:
+                    with open(str(ico_path), "wb") as f:
                         img_small.save(f, format="ICO")
 
                 generated_files.append(str(ico_path))

--- a/shared/favicon_lab.py
+++ b/shared/favicon_lab.py
@@ -81,7 +81,8 @@ class FaviconManager:
                     # of the largest icon to be properly generated, and can sometimes result in
                     # corrupted or empty files if the original is very small (like 1x1 in tests).
                     img_ico = img_ico.resize((48, 48), resample=Image.Resampling.LANCZOS)
-                    img_ico.save(ico_path, format="ICO", sizes=icon_sizes)
+                    with open(ico_path, "wb") as f:
+                        img_ico.save(f, format="ICO", sizes=icon_sizes)
 
                     # Verify the file is actually a valid image
                     with Image.open(ico_path) as _:
@@ -89,7 +90,8 @@ class FaviconManager:
                 except Exception as ico_e:
                     # Fallback if sizes param fails entirely on certain Pillow versions
                     img_small = img.resize((32, 32), resample=Image.Resampling.LANCZOS)
-                    img_small.save(ico_path, format="ICO")
+                    with open(ico_path, "wb") as f:
+                        img_small.save(f, format="ICO")
 
                 generated_files.append(str(ico_path))
 

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -10,13 +10,13 @@ def test_did_you_mean_suggestion():
     root_dir = Path(__file__).parent.parent
     main_script = root_dir / "main.py"
 
-    env = os.environ.copy()
-    existing_pythonpath = env.get('PYTHONPATH', '')
-    env['PYTHONPATH'] = f"{root_dir}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else str(root_dir)
-
     # Run with an invalid command that is close to 'json'
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else str(root_dir)
+
     result = subprocess.run(
-        [sys.executable, str(main_script), "jsno"],
+        ["python3", str(main_script), "jsno"],
         capture_output=True,
         text=True,
         env=env
@@ -38,13 +38,13 @@ def test_did_you_mean_no_suggestion():
     root_dir = Path(__file__).parent.parent
     main_script = root_dir / "main.py"
 
-    env = os.environ.copy()
-    existing_pythonpath = env.get('PYTHONPATH', '')
-    env['PYTHONPATH'] = f"{root_dir}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else str(root_dir)
-
     # Run with a command that has no close matches
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else str(root_dir)
+
     result = subprocess.run(
-        [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],
+        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
         capture_output=True,
         text=True,
         env=env

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -16,7 +16,7 @@ def test_did_you_mean_suggestion():
     env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else str(root_dir)
 
     result = subprocess.run(
-        ["python3", str(main_script), "jsno"],
+        [sys.executable, str(main_script), "jsno"],
         capture_output=True,
         text=True,
         env=env
@@ -44,7 +44,7 @@ def test_did_you_mean_no_suggestion():
     env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else str(root_dir)
 
     result = subprocess.run(
-        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
+        [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],
         capture_output=True,
         text=True,
         env=env

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -16,7 +16,7 @@ def test_did_you_mean_suggestion():
 
     # Run with an invalid command that is close to 'json'
     result = subprocess.run(
-        ["python3", str(main_script), "jsno"],
+        [sys.executable, str(main_script), "jsno"],
         capture_output=True,
         text=True,
         env=env
@@ -44,7 +44,7 @@ def test_did_you_mean_no_suggestion():
 
     # Run with a command that has no close matches
     result = subprocess.run(
-        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
+        [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],
         capture_output=True,
         text=True,
         env=env

--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -54,13 +54,13 @@ def test_generate_favicons(tmp_path):
     assert result["success"] is True
 
     # Verify expected files exist
-    assert (out_dir / "favicon.ico").exists()
-    assert (out_dir / "apple-touch-icon.png").exists()
-    assert (out_dir / "favicon-32x32.png").exists()
-    assert (out_dir / "favicon-16x16.png").exists()
-    assert (out_dir / "android-chrome-192x192.png").exists()
-    assert (out_dir / "android-chrome-512x512.png").exists()
-    assert (out_dir / "site.webmanifest").exists()
+    assert (out_dir / "favicon.ico").is_file()
+    assert (out_dir / "apple-touch-icon.png").is_file()
+    assert (out_dir / "favicon-32x32.png").is_file()
+    assert (out_dir / "favicon-16x16.png").is_file()
+    assert (out_dir / "android-chrome-192x192.png").is_file()
+    assert (out_dir / "android-chrome-512x512.png").is_file()
+    assert (out_dir / "site.webmanifest").is_file()
 
     # Verify site.webmanifest contents
     with open(out_dir / "site.webmanifest", "r") as f:

--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -46,12 +46,13 @@ def test_generate_favicons(tmp_path):
 
     # Create a dummy image
     img = Image.new('RGB', (512, 512), color='red')
-    img.save(str(input_img), format="PNG")
+    with open(str(input_img), "wb") as f:
+        img.save(f, format="PNG")
     assert Path(str(input_img)).is_file(), "Test image was not created!"
 
     result = manager.generate(Path(str(input_img)), Path(str(out_dir)))
 
-    assert result["success"] is True
+    assert result["success"] is True, f"Favicon generation failed: {result.get('error')}"
 
     # Verify expected files exist
     assert (out_dir / "favicon.ico").is_file()


### PR DESCRIPTION
The DidYouMeanArgumentParser tests were failing because `main.py` was being run as a subprocess using the system's `"python3"`, which bypassed the pytest virtual environment where the dependencies are installed. Updating `subprocess.run` to use `sys.executable` ensures the correct environment is used. Additionally, this PR adds `jsonpath-ng` and `tiktoken` to the project's dependencies since they are needed by modules imported globally in `main.py`.

---
*PR created automatically by Jules for task [13592306340491338832](https://jules.google.com/task/13592306340491338832) started by @process-failed-successfully*