### PR TITLE
fix: resolve flake8 E402 and E302 in main.py for DidYouMeanArgumentParser

### DIFF
--- a/main.py
+++ b/main.py
@@ -9778,12 +9778,10 @@ def run_config(args):
     return 0
 
 
-import difflib
-
-
 class DidYouMeanArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         if "invalid choice:" in message and "(choose from" in message:
+            import difflib
             import re
             match = re.search(r"invalid choice: '([^']+)' \(choose from (.+)\)", message)
             if match:
@@ -9800,6 +9798,7 @@ class DidYouMeanArgumentParser(argparse.ArgumentParser):
         self.print_usage(sys.stderr)
         args = {'prog': self.prog, 'message': message}
         self.exit(2, ('%(prog)s: error: %(message)s\n') % args)
+
 
 def parse_args(argv=None):
     parser = DidYouMeanArgumentParser(description="Autonomous Coding Agent")


### PR DESCRIPTION
Fixes CI workflow failure by addressing flake8 styling issues (`E402` and `E302`) in `main.py` introduced in the previous commit.

---
*PR created automatically by Jules for task [16982327486554239843](https://jules.google.com/task/16982327486554239843) started by @process-failed-successfully*