### PR TITLE
fix: add jsonpath-ng and tiktoken to pyproject.toml dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ dependencies = [
     "jq>=1.11.0",
     "mnemonic>=0.21",
     "faker>=24.0.0",
+    "jsonpath-ng",
+    "tiktoken",
 ]
 requires-python = ">=3.11"
 


### PR DESCRIPTION
fix: add jsonpath-ng and tiktoken to pyproject.toml dependencies\n\nThese packages are required for main.py, but were missing from the global dependencies list. This fixes the CI workflow failure when running the CLI tests as a subprocess.

---
*PR created automatically by Jules for task [4437789147457430493](https://jules.google.com/task/4437789147457430493) started by @process-failed-successfully*