### PR TITLE
test: Fix `PYTHONPATH` override in `test_did_you_mean.py`

### DIFF
--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -12,7 +12,7 @@ def test_did_you_mean_suggestion():
 
     # Run with an invalid command that is close to 'json'
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(root_dir)
+    env["PYTHONPATH"] = str(root_dir) + os.pathsep + env.get("PYTHONPATH", "") if env.get("PYTHONPATH") else str(root_dir)
 
     result = subprocess.run(
         [sys.executable, str(main_script), "jsno"],
@@ -39,7 +39,7 @@ def test_did_you_mean_no_suggestion():
 
     # Run with a command that has no close matches
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(root_dir)
+    env["PYTHONPATH"] = str(root_dir) + os.pathsep + env.get("PYTHONPATH", "") if env.get("PYTHONPATH") else str(root_dir)
 
     result = subprocess.run(
         [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],


### PR DESCRIPTION
test: Fix `PYTHONPATH` override in `test_did_you_mean.py`

- Use `os.pathsep` to append/prepend `root_dir` to `PYTHONPATH` instead of overwriting it completely.
- Fixes missing dependencies (`yaml`, `requests`, etc.) when running `pytest tests/test_did_you_mean.py` locally or in CI environments where these paths are passed via `PYTHONPATH`.

---
*PR created automatically by Jules for task [11768634521099839832](https://jules.google.com/task/11768634521099839832) started by @process-failed-successfully*