### PR TITLE
Fix CI test failures for DidYouMean by using sys.executable

### DIFF
--- a/shared/favicon_lab.py
+++ b/shared/favicon_lab.py
@@ -51,7 +51,7 @@ class FaviconManager:
 
                 for filename, size in sizes.items():
                     resized_img = img.resize(size, Image.Resampling.LANCZOS)
-                    resized_img.save(out_dir / filename, format="PNG")
+                    resized_img.save(str(out_dir / filename), format="PNG")
 
                 # Generate favicon.ico using a copy as per memory instructions
                 # "When saving images in ICO format with multiple sizes using Pillow... operate on a copy of the image (img.copy())."
@@ -59,7 +59,7 @@ class FaviconManager:
                 if max(ico_copy.size) < 48:
                     ico_copy = ico_copy.resize((48, 48), Image.Resampling.LANCZOS)
                 ico_copy.save(
-                    out_dir / "favicon.ico",
+                    str(out_dir / "favicon.ico"),
                     format="ICO",
                     sizes=[(16, 16), (32, 32), (48, 48)]
                 )

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -11,11 +11,14 @@ def test_did_you_mean_suggestion():
     main_script = root_dir / "main.py"
 
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(root_dir)
+    if "PYTHONPATH" in env:
+        env["PYTHONPATH"] = f"{str(root_dir)}{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = str(root_dir)
 
     # Run with an invalid command that is close to 'json'
     result = subprocess.run(
-        ["python3", str(main_script), "jsno"],
+        [sys.executable, str(main_script), "jsno"],
         capture_output=True,
         text=True,
         env=env
@@ -38,11 +41,14 @@ def test_did_you_mean_no_suggestion():
     main_script = root_dir / "main.py"
 
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(root_dir)
+    if "PYTHONPATH" in env:
+        env["PYTHONPATH"] = f"{str(root_dir)}{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = str(root_dir)
 
     # Run with a command that has no close matches
     result = subprocess.run(
-        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
+        [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],
         capture_output=True,
         text=True,
         env=env

--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -22,7 +22,8 @@ def temp_image_path(tmp_path):
     img_path = tmp_path / "test_logo.png"
     # Create a small red image
     img = Image.new('RGB', (100, 100), color='red')
-    img.save(img_path)
+    with open(str(img_path), 'wb') as f:
+        img.save(f, format='PNG')
     return str(img_path)
 
 


### PR DESCRIPTION
Fix CI test failures for the DidYouMean feature by ensuring correct Python interpreter paths and safe `PYTHONPATH` manipulation during subprocess test execution.

---
*PR created automatically by Jules for task [1594715755556284495](https://jules.google.com/task/1594715755556284495) started by @process-failed-successfully*