### PR TITLE
Fix CI failure by using sys.executable in test_did_you_mean.py

### DIFF
--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -16,7 +16,7 @@ def test_did_you_mean_suggestion():
 
     # Run with an invalid command that is close to 'json'
     result = subprocess.run(
-        ["python3", str(main_script), "jsno"],
+        [sys.executable, str(main_script), "jsno"],
         capture_output=True,
         text=True,
         env=env
@@ -44,7 +44,7 @@ def test_did_you_mean_no_suggestion():
 
     # Run with a command that has no close matches
     result = subprocess.run(
-        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
+        [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],
         capture_output=True,
         text=True,
         env=env


### PR DESCRIPTION
The recent PR adding command-line suggestions caused a CI failure because `tests/test_did_you_mean.py` spawned a subprocess using the hardcoded string `"python3"`. In the CI environment (or virtual environments), `python3` may not correspond to the environment where pytest is running, or it might lack the project's dependencies (e.g., `yaml`). This change updates the test to use `sys.executable`, ensuring the subprocess runs in the exact same environment as pytest, resolving `ModuleNotFoundError` issues and robustly passing tests.

---
*PR created automatically by Jules for task [3386702766708360117](https://jules.google.com/task/3386702766708360117) started by @process-failed-successfully*