### PR TITLE
Fix test_did_you_mean.py to use sys.executable and PYTHONPATH

### DIFF
--- a/shared/favicon_lab.py
+++ b/shared/favicon_lab.py
@@ -49,7 +49,7 @@ class FaviconManager:
                 # Generate Apple Touch Icon (180x180)
                 apple_path = output_dir / "apple-touch-icon.png"
                 img_apple = img.resize((180, 180), resample=Image.Resampling.LANCZOS)
-                img_apple.save(apple_path, format="PNG")
+                img_apple.save(str(apple_path), format="PNG")
                 generated_files.append(str(apple_path))
 
                 # Generate standard size PNGs (32x32, 16x16)
@@ -57,7 +57,7 @@ class FaviconManager:
                 for size in png_sizes:
                     png_path = output_dir / f"favicon-{size[0]}x{size[1]}.png"
                     img_png = img.resize(size, resample=Image.Resampling.LANCZOS)
-                    img_png.save(png_path, format="PNG")
+                    img_png.save(str(png_path), format="PNG")
                     generated_files.append(str(png_path))
 
                 # Generate Android Chrome Icons
@@ -65,7 +65,7 @@ class FaviconManager:
                 for size in android_sizes:
                     android_path = output_dir / f"android-chrome-{size[0]}x{size[1]}.png"
                     img_android = img.resize(size, resample=Image.Resampling.LANCZOS)
-                    img_android.save(android_path, format="PNG")
+                    img_android.save(str(android_path), format="PNG")
                     generated_files.append(str(android_path))
 
                 # Generate favicon.ico (multi-resolution: 16x16, 32x32, 48x48)
@@ -81,15 +81,15 @@ class FaviconManager:
                     # of the largest icon to be properly generated, and can sometimes result in
                     # corrupted or empty files if the original is very small (like 1x1 in tests).
                     img_ico = img_ico.resize((48, 48), resample=Image.Resampling.LANCZOS)
-                    img_ico.save(ico_path, format="ICO", sizes=icon_sizes)
+                    img_ico.save(str(ico_path), format="ICO", sizes=icon_sizes)
 
                     # Verify the file is actually a valid image
-                    with Image.open(ico_path) as _:
+                    with Image.open(str(ico_path)) as _:
                         pass
                 except Exception as ico_e:
                     # Fallback if sizes param fails entirely on certain Pillow versions
                     img_small = img.resize((32, 32), resample=Image.Resampling.LANCZOS)
-                    img_small.save(ico_path, format="ICO")
+                    img_small.save(str(ico_path), format="ICO")
 
                 generated_files.append(str(ico_path))
 

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -9,11 +10,18 @@ def test_did_you_mean_suggestion():
     root_dir = Path(__file__).parent.parent
     main_script = root_dir / "main.py"
 
+    env = os.environ.copy()
+    if "PYTHONPATH" in env:
+        env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = str(root_dir)
+
     # Run with an invalid command that is close to 'json'
     result = subprocess.run(
-        ["python3", str(main_script), "jsno"],
+        [sys.executable, str(main_script), "jsno"],
         capture_output=True,
-        text=True
+        text=True,
+        env=env
     )
 
     assert result.returncode == 2
@@ -32,11 +40,18 @@ def test_did_you_mean_no_suggestion():
     root_dir = Path(__file__).parent.parent
     main_script = root_dir / "main.py"
 
+    env = os.environ.copy()
+    if "PYTHONPATH" in env:
+        env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = str(root_dir)
+
     # Run with a command that has no close matches
     result = subprocess.run(
-        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
+        [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],
         capture_output=True,
-        text=True
+        text=True,
+        env=env
     )
 
     assert result.returncode == 2


### PR DESCRIPTION
This fixes the failures in tests/test_did_you_mean.py introduced in the last commit by switching to `sys.executable` and setting the `PYTHONPATH` environment correctly when launching subprocesses.

---
*PR created automatically by Jules for task [7979892900590535154](https://jules.google.com/task/7979892900590535154) started by @process-failed-successfully*