### PR TITLE
Fix E402 import error and formatting in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ Combined Autonomous Coding Agent
 Main entry point for running autonomous coding agents (Gemini or Cursor).
 """
 
+import difflib
+
 from shared.cli_utils import _run_history_graph_logic
 from shared.cli_utils import get_workflow_stage, WORKFLOW_STAGES, WORKFLOW_ORDER
 from shared.cli_utils import (
@@ -9778,9 +9780,6 @@ def run_config(args):
     return 0
 
 
-import difflib
-
-
 class DidYouMeanArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         if "invalid choice:" in message and "(choose from" in message:
@@ -9800,6 +9799,7 @@ class DidYouMeanArgumentParser(argparse.ArgumentParser):
         self.print_usage(sys.stderr)
         args = {'prog': self.prog, 'message': message}
         self.exit(2, ('%(prog)s: error: %(message)s\n') % args)
+
 
 def parse_args(argv=None):
     parser = DidYouMeanArgumentParser(description="Autonomous Coding Agent")

--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -46,7 +46,8 @@ def test_generate_favicons(tmp_path):
 
     # Create a dummy image
     img = Image.new('RGB', (512, 512), color='red')
-    img.save(str(input_img), format="PNG")
+    with open(str(input_img), 'wb') as f:
+        img.save(f, format="PNG")
     img.close()
 
     assert input_img.is_file(), "Test image was not created!"


### PR DESCRIPTION
Fixes the E402 module level import issue and related formatting around DidYouMeanArgumentParser to pass CI tests.

---
*PR created automatically by Jules for task [17596577657498700312](https://jules.google.com/task/17596577657498700312) started by @process-failed-successfully*