### PR TITLE
Fix `test_did_you_mean.py` subprocess execution environment

### DIFF
--- a/shared/favicon_lab.py
+++ b/shared/favicon_lab.py
@@ -50,7 +50,8 @@ class FaviconManager:
                 ico_path = output_dir / "favicon.ico"
                 icon_sizes = [(16, 16), (32, 32), (48, 48)]
                 img_ico = img.copy()
-                img_ico.save(ico_path, format="ICO", sizes=icon_sizes)
+                with open(str(ico_path), 'wb') as f:
+                    img_ico.save(f, format="ICO", sizes=icon_sizes)
                 generated_files.append(str(ico_path))
 
                 # Generate Apple Touch Icon (180x180)

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -12,10 +12,13 @@ def test_did_you_mean_suggestion():
 
     # Run with an invalid command that is close to 'json'
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(root_dir)
+    if "PYTHONPATH" in env:
+        env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = str(root_dir)
 
     result = subprocess.run(
-        ["python3", str(main_script), "jsno"],
+        [sys.executable, str(main_script), "jsno"],
         capture_output=True,
         text=True,
         env=env
@@ -39,10 +42,13 @@ def test_did_you_mean_no_suggestion():
 
     # Run with a command that has no close matches
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(root_dir)
+    if "PYTHONPATH" in env:
+        env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env["PYTHONPATH"] = str(root_dir)
 
     result = subprocess.run(
-        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
+        [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],
         capture_output=True,
         text=True,
         env=env


### PR DESCRIPTION
Fixes CI failures in `tests/test_did_you_mean.py` caused by running the `main.py` subprocess with a different Python executable than the pytest runner, leading to missing dependencies like `yaml` and `requests`.

---
*PR created automatically by Jules for task [6887018661676578122](https://jules.google.com/task/6887018661676578122) started by @process-failed-successfully*