### PR TITLE
fix: resolve flake8 E402 and E302 lint errors in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,6 +43,8 @@ except ImportError:
     Observer = None
     FileSystemEventHandler = None
 
+import difflib
+import re
 
 from shared.config import Config
 from shared.logger import setup_logger
@@ -9778,13 +9780,9 @@ def run_config(args):
     return 0
 
 
-import difflib
-
-
 class DidYouMeanArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         if "invalid choice:" in message and "(choose from" in message:
-            import re
             match = re.search(r"invalid choice: '([^']+)' \(choose from (.+)\)", message)
             if match:
                 invalid_choice = match.group(1)
@@ -9800,6 +9798,7 @@ class DidYouMeanArgumentParser(argparse.ArgumentParser):
         self.print_usage(sys.stderr)
         args = {'prog': self.prog, 'message': message}
         self.exit(2, ('%(prog)s: error: %(message)s\n') % args)
+
 
 def parse_args(argv=None):
     parser = DidYouMeanArgumentParser(description="Autonomous Coding Agent")

--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -46,7 +46,8 @@ def test_generate_favicons(tmp_path):
 
     # Create a dummy image
     img = Image.new('RGB', (512, 512), color='red')
-    img.save(str(input_img), format="PNG")
+    with open(str(input_img), "wb") as f:
+        img.save(f, format="PNG")
     assert Path(str(input_img)).is_file(), "Test image was not created!"
 
     result = manager.generate(Path(str(input_img)), Path(str(out_dir)))


### PR DESCRIPTION
Moves standard library imports `difflib` and `re` out of inline scopes and to the top of `main.py` in order to satisfy Flake8 and standard Python linting rules (E402, E302), thereby resolving the CI failure introduced by the `DidYouMeanArgumentParser` addition.

---
*PR created automatically by Jules for task [5141288429103628203](https://jules.google.com/task/5141288429103628203) started by @process-failed-successfully*