### PR TITLE
fix: resolve Flake8 E402 and E302 errors in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ import subprocess
 from pathlib import Path
 import time
 from collections import deque
+import difflib
 try:
     from watchdog.observers import Observer
     from watchdog.events import FileSystemEventHandler
@@ -9778,9 +9779,6 @@ def run_config(args):
     return 0
 
 
-import difflib
-
-
 class DidYouMeanArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         if "invalid choice:" in message and "(choose from" in message:
@@ -9800,6 +9798,7 @@ class DidYouMeanArgumentParser(argparse.ArgumentParser):
         self.print_usage(sys.stderr)
         args = {'prog': self.prog, 'message': message}
         self.exit(2, ('%(prog)s: error: %(message)s\n') % args)
+
 
 def parse_args(argv=None):
     parser = DidYouMeanArgumentParser(description="Autonomous Coding Agent")


### PR DESCRIPTION
- Moved `import difflib` to the top of `main.py`.
- Added required blank lines to satisfy Flake8.
- Tested and verified tests continue to pass and `flake8` no longer emits E402/E302 for these lines.

---
*PR created automatically by Jules for task [6950646602146734547](https://jules.google.com/task/6950646602146734547) started by @process-failed-successfully*