### PR TITLE
fix: resolve flake8 errors in main.py and tests/test_did_you_mean.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ import shutil
 import subprocess
 from pathlib import Path
 import time
+import difflib
 from collections import deque
 try:
     from watchdog.observers import Observer
@@ -9778,7 +9779,6 @@ def run_config(args):
     return 0
 
 
-import difflib
 
 
 class DidYouMeanArgumentParser(argparse.ArgumentParser):
@@ -9800,6 +9800,7 @@ class DidYouMeanArgumentParser(argparse.ArgumentParser):
         self.print_usage(sys.stderr)
         args = {'prog': self.prog, 'message': message}
         self.exit(2, ('%(prog)s: error: %(message)s\n') % args)
+
 
 def parse_args(argv=None):
     parser = DidYouMeanArgumentParser(description="Autonomous Coding Agent")

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+
 def test_did_you_mean_suggestion():
     """
     Test that running main.py with an invalid command suggests closely matching valid commands.
@@ -32,6 +33,7 @@ def test_did_you_mean_suggestion():
     # Our new DidYouMean suggestion should be there
     assert "Did you mean:" in result.stderr
     assert "'json'" in result.stderr
+
 
 def test_did_you_mean_no_suggestion():
     """


### PR DESCRIPTION
This PR resolves the `Robust CI` workflow failures which occurred because `flake8` reported stylistic errors:
- E402: `import difflib` was used inside `main.py` but not at the top-level block.
- E302: There were missing blank lines between classes and methods in `main.py` around the newly added `DidYouMeanArgumentParser` and inside `tests/test_did_you_mean.py`.

The fix was to move `import difflib` to the top of the file and ensure spacing meets PEP 8 guidelines. Tests still successfully run locally to confirm these changes haven't broken the test module logic.

---
*PR created automatically by Jules for task [12479549911035926621](https://jules.google.com/task/12479549911035926621) started by @process-failed-successfully*