### PR TITLE
fix: test_did_you_mean to use sys.executable in subprocess calls

### DIFF
--- a/shared/favicon_lab.py
+++ b/shared/favicon_lab.py
@@ -49,7 +49,8 @@ class FaviconManager:
                 # Generate Apple Touch Icon (180x180)
                 apple_path = output_dir / "apple-touch-icon.png"
                 img_apple = img.resize((180, 180), resample=Image.Resampling.LANCZOS)
-                img_apple.save(apple_path, format="PNG")
+                with open(str(apple_path), "wb") as f:
+                    img_apple.save(f, format="PNG")
                 generated_files.append(str(apple_path))
 
                 # Generate standard size PNGs (32x32, 16x16)
@@ -57,7 +58,8 @@ class FaviconManager:
                 for size in png_sizes:
                     png_path = output_dir / f"favicon-{size[0]}x{size[1]}.png"
                     img_png = img.resize(size, resample=Image.Resampling.LANCZOS)
-                    img_png.save(png_path, format="PNG")
+                    with open(str(png_path), "wb") as f:
+                        img_png.save(f, format="PNG")
                     generated_files.append(str(png_path))
 
                 # Generate Android Chrome Icons
@@ -65,7 +67,8 @@ class FaviconManager:
                 for size in android_sizes:
                     android_path = output_dir / f"android-chrome-{size[0]}x{size[1]}.png"
                     img_android = img.resize(size, resample=Image.Resampling.LANCZOS)
-                    img_android.save(android_path, format="PNG")
+                    with open(str(android_path), "wb") as f:
+                        img_android.save(f, format="PNG")
                     generated_files.append(str(android_path))
 
                 # Generate favicon.ico (multi-resolution: 16x16, 32x32, 48x48)
@@ -81,7 +84,7 @@ class FaviconManager:
                     # of the largest icon to be properly generated, and can sometimes result in
                     # corrupted or empty files if the original is very small (like 1x1 in tests).
                     img_ico = img_ico.resize((48, 48), resample=Image.Resampling.LANCZOS)
-                    with open(ico_path, "wb") as f:
+                    with open(str(ico_path), "wb") as f:
                         img_ico.save(f, format="ICO", sizes=icon_sizes)
 
                     # Verify the file is actually a valid image
@@ -90,7 +93,7 @@ class FaviconManager:
                 except Exception as ico_e:
                     # Fallback if sizes param fails entirely on certain Pillow versions
                     img_small = img.resize((32, 32), resample=Image.Resampling.LANCZOS)
-                    with open(ico_path, "wb") as f:
+                    with open(str(ico_path), "wb") as f:
                         img_small.save(f, format="ICO")
 
                 generated_files.append(str(ico_path))

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -16,7 +16,7 @@ def test_did_you_mean_suggestion():
     env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else str(root_dir)
 
     result = subprocess.run(
-        ["python3", str(main_script), "jsno"],
+        [sys.executable, str(main_script), "jsno"],
         capture_output=True,
         text=True,
         env=env
@@ -44,7 +44,7 @@ def test_did_you_mean_no_suggestion():
     env["PYTHONPATH"] = f"{root_dir}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else str(root_dir)
 
     result = subprocess.run(
-        ["python3", str(main_script), "xyz123thisisnotacommandatall"],
+        [sys.executable, str(main_script), "xyz123thisisnotacommandatall"],
         capture_output=True,
         text=True,
         env=env


### PR DESCRIPTION
This pull request fixes the CI failure caused by the recently added `test_did_you_mean.py` where it used `python3` instead of `sys.executable`.
    
    The issue occurred because the global `python3` was executing the tests in an environment that didn't have the necessary packages (like `yaml` and `platformdirs`) installed, while `sys.executable` points to the test runner's virtual environment where all dependencies are satisfied.

---
*PR created automatically by Jules for task [16814087673597988878](https://jules.google.com/task/16814087673597988878) started by @process-failed-successfully*