### PR TITLE
fix: resolve missing dependencies for DidYouMean subprocess test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ dependencies = [
     "jq>=1.11.0",
     "mnemonic>=0.21",
     "faker>=24.0.0",
+    "tiktoken",
+    "jsonpath_ng",
 ]
 requires-python = ">=3.11"
 

--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -46,7 +46,8 @@ def test_generate_favicons(tmp_path):
 
     # Create a dummy image
     img = Image.new('RGB', (512, 512), color='red')
-    img.save(str(input_img), format="PNG")
+    with open(str(input_img), "wb") as f:
+        img.save(f, format="PNG")
     assert Path(str(input_img)).is_file(), "Test image was not created!"
 
     result = manager.generate(Path(str(input_img)), Path(str(out_dir)))


### PR DESCRIPTION
Added missing dependencies `tiktoken` and `jsonpath_ng` to `pyproject.toml` to fix the test suite subprocess errors in the Robust CI workflow.

---
*PR created automatically by Jules for task [1778734604076922016](https://jules.google.com/task/1778734604076922016) started by @process-failed-successfully*