### PR TITLE
fix: fix PEP 8 E402/E302 errors in did-you-mean feature

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ from shared.cli_utils import (
     _parse_metrics,
 )
 import argparse
+import difflib
 import asyncio
 try:
     import argcomplete
@@ -9778,9 +9779,6 @@ def run_config(args):
     return 0
 
 
-import difflib
-
-
 class DidYouMeanArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         if "invalid choice:" in message and "(choose from" in message:
@@ -9800,6 +9798,7 @@ class DidYouMeanArgumentParser(argparse.ArgumentParser):
         self.print_usage(sys.stderr)
         args = {'prog': self.prog, 'message': message}
         self.exit(2, ('%(prog)s: error: %(message)s\n') % args)
+
 
 def parse_args(argv=None):
     parser = DidYouMeanArgumentParser(description="Autonomous Coding Agent")

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+
 def test_did_you_mean_suggestion():
     """
     Test that running main.py with an invalid command suggests closely matching valid commands.
@@ -30,6 +31,7 @@ def test_did_you_mean_suggestion():
     # Our new DidYouMean suggestion should be there
     assert "Did you mean:" in result.stderr
     assert "'json'" in result.stderr
+
 
 def test_did_you_mean_no_suggestion():
     """


### PR DESCRIPTION
Fix flake8 E402 and E302 formatting issues in `main.py` and `tests/test_did_you_mean.py` that caused CI failure.

---
*PR created automatically by Jules for task [13251887581397219413](https://jules.google.com/task/13251887581397219413) started by @process-failed-successfully*