### PR TITLE
fix: resolve missing dependencies and flake8 formatting errors in CLI tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -463,6 +463,7 @@ def run_arn_lab(args):
     run_arn_lab_logic(args)
     sys.exit(0)
 
+
 def run_calc_lab(args):
     """Runs the Calc Lab (Programmer's Calculator)."""
     if getattr(args, "tui", False):
@@ -836,6 +837,7 @@ def run_phonetic_lab(args):
     from shared.phonetic_lab import run_phonetic_lab_logic
     run_phonetic_lab_logic(args)
     sys.exit(0)
+
 
 def run_nato_lab(args):
     """Runs the NATO Lab."""
@@ -2448,6 +2450,7 @@ def run_faker_lab(args):
     if not success:
         sys.exit(1)
 
+
 def run_geo_lab(args):
     """Runs the Geo Lab."""
     if getattr(args, "action", None) == "tui" or getattr(args, "tui", False):
@@ -2531,6 +2534,7 @@ def run_amqp_lab(args):
     from shared.amqp_lab import run_amqp_lab_logic
     run_amqp_lab_logic(args)
     sys.exit(0)
+
 
 def run_pcap_lab(args):
     """Runs the PCAP Lab."""
@@ -2725,6 +2729,7 @@ def run_mongo_lab(args):
 
     from shared.mongo_lab import run_mongo_lab_logic
     run_mongo_lab_logic(args)
+
 
 def run_redis_lab(args):
     """Runs the Redis Lab."""
@@ -2990,6 +2995,7 @@ def run_ksuid_lab(args):
     from shared.ksuid_lab import run_ksuid_lab_logic
     run_ksuid_lab_logic(args)
     sys.exit(0)
+
 
 def run_uuid_lab(args):
     """Runs the UUID Lab."""
@@ -3315,6 +3321,7 @@ def run_json2py_lab(args):
     from shared.json2py_lab import run_json2py_lab_logic
     success = run_json2py_lab_logic(args)
     sys.exit(0 if success else 1)
+
 
 def run_json2xml_lab(args):
     """Runs the JSON to XML Lab."""
@@ -21122,6 +21129,7 @@ def run_mask_lab(args):
 
     from shared.mask_lab import run_mask_lab_logic
     run_mask_lab_logic(args)
+
 
 def run_regex_escape_lab(args):
     """Runs the Regex Escape Lab."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ dependencies = [
     "jq>=1.11.0",
     "mnemonic>=0.21",
     "faker>=24.0.0",
+    "jsonpath-ng",
+    "tiktoken",
 ]
 requires-python = ">=3.11"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dependencies = [
     "faker>=24.0.0",
     "jsonpath-ng",
     "tiktoken",
+    "pytest-asyncio",
 ]
 requires-python = ">=3.11"
 

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+
 def test_did_you_mean_suggestion():
     """
     Test that running main.py with an invalid command suggests closely matching valid commands.
@@ -31,6 +32,7 @@ def test_did_you_mean_suggestion():
     # Our new DidYouMean suggestion should be there
     assert "Did you mean:" in result.stderr
     assert "'json'" in result.stderr
+
 
 def test_did_you_mean_no_suggestion():
     """


### PR DESCRIPTION
Fixes CI workflow failure introduced by a recent commit. The test runner failed because the newly introduced CLI commands failed globally from missing dependencies, and the newly added code contained multiple PEP8 formatting issues.

Changes:
- Added `jsonpath-ng` and `tiktoken` to `pyproject.toml` dependencies.
- Added blank lines to `tests/test_did_you_mean.py` and `main.py` to fix flake8 E302.

---
*PR created automatically by Jules for task [4089360574497948523](https://jules.google.com/task/4089360574497948523) started by @process-failed-successfully*