### PR TITLE
Fix: Add missing dependencies to pyproject.toml to resolve test crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ dependencies = [
     "jq>=1.11.0",
     "mnemonic>=0.21",
     "faker>=24.0.0",
+    "jsonpath-ng",
+    "tiktoken",
 ]
 requires-python = ">=3.11"
 


### PR DESCRIPTION
Added `jsonpath-ng` and `tiktoken` to `dependencies` array in `pyproject.toml`. This fixes `ModuleNotFoundError` errors caused by these missing packages when running tests using subprocess with `main.py`.

---
*PR created automatically by Jules for task [5639255524783274868](https://jules.google.com/task/5639255524783274868) started by @process-failed-successfully*