### PR TITLE
fix: prevent image mutation and intermittent test failures in Favicon Lab

### DIFF
--- a/shared/favicon_lab.py
+++ b/shared/favicon_lab.py
@@ -41,7 +41,7 @@ class FaviconManager:
                 ico_sizes = [(16, 16), (32, 32), (48, 48)]
                 ico_path = out_dir / "favicon.ico"
                 with open(str(ico_path), 'wb') as f:
-                    img.save(f, format='ICO', sizes=ico_sizes)
+                    img.copy().save(f, format='ICO', sizes=ico_sizes)
                 print(f"✅ Generated {ico_path}")
 
                 # Generate apple-touch-icon.png

--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -14,7 +14,8 @@ def test_generate_favicons():
 
         # Create a valid 512x512 mock image
         img = Image.new("RGBA", (512, 512), color="red")
-        img.save(str(img_path))
+        with open(str(img_path), 'wb') as f:
+            img.save(f, format='PNG')
 
         manager = FaviconManager(tmp_path)
         success = manager.generate("logo.png", "out_dir")
@@ -45,7 +46,8 @@ def test_generate_favicons_too_small():
 
         # Create an invalid 256x256 mock image
         img = Image.new("RGBA", (256, 256), color="red")
-        img.save(str(img_path))
+        with open(str(img_path), 'wb') as f:
+            img.save(f, format='PNG')
 
         manager = FaviconManager(tmp_path)
         success = manager.generate("small.png", "out_dir")
@@ -77,7 +79,8 @@ def test_run_favicon_lab_logic_generate(monkeypatch):
         img_path = tmp_path / "logo.png"
 
         img = Image.new("RGBA", (512, 512), color="blue")
-        img.save(str(img_path))
+        with open(str(img_path), 'wb') as f:
+            img.save(f, format='PNG')
 
         args = argparse.Namespace(
             project_dir=tmp_path,

--- a/tests/test_tui_favicon.py
+++ b/tests/test_tui_favicon.py
@@ -24,7 +24,8 @@ async def test_favicon_lab_tui_load_and_generate(temp_project_dir):
         # Prepare a valid source image
         img_path = temp_project_dir / "logo.png"
         img = Image.new("RGBA", (512, 512), color="red")
-        img.save(str(img_path))
+        with open(str(img_path), 'wb') as f:
+            img.save(f, format='PNG')
 
         app.query_one("#favicon-image-input").value = "logo.png"
         app.query_one("#favicon-output-input").value = "out_dir"


### PR DESCRIPTION
This PR addresses intermittent CI test failures in the Favicon Lab tests (`test_favicon_lab.py` and `test_tui_favicon.py`). The issue stems from Pillow mutating the image object during ICO multi-size saving, and from asynchronous file flushing when writing mock images to disk during tests without an explicit context manager.

Key changes:
- In `shared/favicon_lab.py`: Changed `img.save(f, format='ICO', sizes=ico_sizes)` to use `img.copy()` to avoid mutating the original image in place.
- In `tests/test_favicon_lab.py` and `tests/test_tui_favicon.py`: Refactored mock image generation calls like `img.save(str(img_path))` to explicitly manage the file descriptor lifecycle via `with open(str(img_path), 'wb') as f: img.save(f, format='PNG')`. This guarantees the image is written synchronously before assertions evaluate.

---
*PR created automatically by Jules for task [5602332283685669535](https://jules.google.com/task/5602332283685669535) started by @process-failed-successfully*