### PR TITLE
Fix FaviconLab PIL image mutation bug

### DIFF
--- a/shared/favicon_lab.py
+++ b/shared/favicon_lab.py
@@ -41,7 +41,7 @@ class FaviconManager:
                 ico_sizes = [(16, 16), (32, 32), (48, 48)]
                 ico_path = out_dir / "favicon.ico"
                 with open(str(ico_path), 'wb') as f:
-                    img.save(f, format='ICO', sizes=ico_sizes)
+                    img.copy().save(f, format='ICO', sizes=ico_sizes)
                 print(f"✅ Generated {ico_path}")
 
                 # Generate apple-touch-icon.png


### PR DESCRIPTION
Fixes a CI failure in `test_favicon_lab.py` where generating the `apple-touch-icon.png` failed because saving the image as a multi-resolution `.ico` mutated the original image state. The fix ensures we call `.copy()` before saving the `.ico`.

---
*PR created automatically by Jules for task [13908596306335879042](https://jules.google.com/task/13908596306335879042) started by @process-failed-successfully*