### PR TITLE
fix: gracefully handle missing Pillow dependency in favicon tests

### DIFF
--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -1,9 +1,10 @@
 import pytest
 from pathlib import Path
-from PIL import Image
 import tempfile
 import sys
 import argparse
+
+Image = pytest.importorskip("PIL.Image")
 
 from shared.favicon_lab import FaviconManager, run_favicon_lab_logic
 

--- a/tests/test_tui_favicon.py
+++ b/tests/test_tui_favicon.py
@@ -1,7 +1,8 @@
 import pytest
 from pathlib import Path
 import tempfile
-from PIL import Image
+
+Image = pytest.importorskip("PIL.Image")
 
 from shared.tui import AgentTUI
 


### PR DESCRIPTION
Fixes a CI pipeline failure caused by a `ModuleNotFoundError: No module named 'PIL'` during test collection.

The favicon lab tests (`test_favicon_lab.py` and `test_tui_favicon.py`) rely on the `Pillow` library, which is an optional dependency. Directly importing `Image` from `PIL` causes the test runner to crash if the library isn't present in the environment.

This fix replaces the direct import with `Image = pytest.importorskip("PIL.Image")`. This idiomatic pytest feature gracefully skips the test modules if the dependency is missing, rather than halting execution, and acts as a standard import when the library is present.

---
*PR created automatically by Jules for task [13967230437894958190](https://jules.google.com/task/13967230437894958190) started by @process-failed-successfully*