### PR TITLE
fix: restore missing KNOWN_COMMANDS and add Entropy Lab

### DIFF
--- a/main.py
+++ b/main.py
@@ -260,7 +260,7 @@ KNOWN_COMMANDS = [
     "bencode-lab", "bencode", "torrent",
     "msgpack-lab", "msgpack", "mpack",
     "bson-lab", "bson",
-    "crypto-lab", "crypto", "json-lab", "json", "csv-lab", "csv", "csv2sql-lab", "csv2sql", "c2s", "json2sql-lab", "json2sql", "j2s", "csv2html-lab", "csv2html", "c2h", "json2csv-lab", "j2c", "favicon-lab", "favicon", "json2ini-lab", "json2ini", "j2i", "csv2json-lab", "c2j", "csv2yaml-lab", "csv2yaml", "c2y", "env2json-lab", "env2json", "json2env", "json2md-lab", "json2md", "csv2md-lab", "csv2md", "md2csv-lab", "md2csv", "m2c", "csv2toml-lab", "csv2toml", "c2t", "yaml2csv-lab", "yaml2csv", "y2c", "xml2csv-lab", "xml2csv", "x2c", "toml2csv-lab", "toml2csv", "t2c", "yaml2json-lab", "yaml2json", "y2j", "json2py-lab", "json2py", "j2py", "json2yaml-lab", "json2yaml", "j2y", "yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t", "xml2toml-lab", "xml2toml", "toml2xml", "x2t", "json2toml-lab", "json2toml", "j2t", "xml2yaml-lab", "xml2yaml", "x2y", "yaml2xml-lab", "yaml2xml", "y2x", "yaml2py-lab", "yaml2py", "y2py", "json2ts-lab", "json2ts", "j2ts", "json2go-lab", "json2go", "j2go", "json2dart-lab", "json2dart", "j2dart", "json2swift-lab", "json2swift", "j2swift", "json2csharp-lab", "json2csharp", "j2cs", "json2rust-lab", "json2rust", "j2rs", "excel-lab", "xls", "xlsx", "excel", "template-lab", "tpl", "image-lab", "img", "exif-lab", "exif", "ocr-lab", "ocr", "media-lab", "media", "xml-lab", "xml", "lorem-lab", "lorem", "lipsum", "bip39-lab", "bip39", "magic-decode-lab", "magic-decode", "mdecode", "endian-lab", "endian",
+    "crypto-lab", "crypto", "json-lab", "json", "csv-lab", "csv", "csv2sql-lab", "csv2sql", "c2s", "json2sql-lab", "json2sql", "j2s", "csv2html-lab", "csv2html", "c2h", "json2csv-lab", "j2c", "favicon-lab", "favicon", "entropy-lab", "entropy", "json2ini-lab", "json2ini", "j2i", "csv2json-lab", "c2j", "csv2yaml-lab", "csv2yaml", "c2y", "env2json-lab", "env2json", "json2env", "json2md-lab", "json2md", "csv2md-lab", "csv2md", "md2csv-lab", "md2csv", "m2c", "csv2toml-lab", "csv2toml", "c2t", "yaml2csv-lab", "yaml2csv", "y2c", "xml2csv-lab", "xml2csv", "x2c", "toml2csv-lab", "toml2csv", "t2c", "yaml2json-lab", "yaml2json", "y2j", "json2py-lab", "json2py", "j2py", "json2yaml-lab", "json2yaml", "j2y", "yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t", "xml2toml-lab", "xml2toml", "toml2xml", "x2t", "json2toml-lab", "json2toml", "j2t", "xml2yaml-lab", "xml2yaml", "x2y", "yaml2xml-lab", "yaml2xml", "y2x", "yaml2py-lab", "yaml2py", "y2py", "json2ts-lab", "json2ts", "j2ts", "json2go-lab", "json2go", "j2go", "json2dart-lab", "json2dart", "j2dart", "json2swift-lab", "json2swift", "j2swift", "json2csharp-lab", "json2csharp", "j2cs", "json2rust-lab", "json2rust", "j2rs", "excel-lab", "xls", "xlsx", "excel", "template-lab", "tpl", "image-lab", "img", "exif-lab", "exif", "ocr-lab", "ocr", "media-lab", "media", "xml-lab", "xml", "lorem-lab", "lorem", "lipsum", "bip39-lab", "bip39", "magic-decode-lab", "magic-decode", "mdecode", "endian-lab", "endian",
     "ical-lab", "ical", "ics",
     "markdown-lab", "md", "md-lab", "yaml-lab", "yaml", "ini-lab", "ini", "toml-lab", "toml", "net-lab", "net", "archive-lab", "arc",
     "plist-lab", "plist", "plist2json", "json2plist",
@@ -16249,6 +16249,16 @@ def parse_args(argv=None):
     parser_hexdump.add_argument("--length", "-l", type=int, default=-1, help="Number of bytes to read (-1 for all).")
     parser_hexdump.add_argument("--tui", action="store_true", help="Launch the Hexdump Lab TUI.")
 
+    # --- New 'entropy-lab' command ---
+    parser_entropy = subparsers.add_parser(
+        "entropy-lab",
+        aliases=["entropy"],
+        help="Entropy Lab: Calculate Shannon entropy and analyze data."
+    )
+    parser_entropy.add_argument("--file", "-f", help="File to read from.")
+    parser_entropy.add_argument("--text", "-t", help="Text to analyze.")
+    parser_entropy.add_argument("--tui", action="store_true", help="Launch the Entropy Lab TUI.")
+
     # --- New 'filetype-lab' command ---
     parser_filetype = subparsers.add_parser(
         "filetype-lab",
@@ -25398,6 +25408,25 @@ async def main():
             from shared.phone_lab import run_phone_lab_logic
             run_phone_lab_logic(args)
         else:
+            sys.exit(1)
+        return
+
+    if args.command in ["entropy-lab", "entropy"]:
+        # TUI mode
+        if getattr(args, "tui", False):
+            print("Launching Entropy Lab TUI...")
+            app = AgentTUI(project_dir=getattr(args, 'project_dir', Path(".")), start_tab="tab-entropy")
+            if hasattr(app, "run_async"):
+                import asyncio
+                asyncio.run(app.run_async())
+            else:
+                app.run()
+            return
+
+        # CLI mode
+        from shared.entropy_lab import run_entropy_lab_logic
+        success = run_entropy_lab_logic(args)
+        if not success:
             sys.exit(1)
         return
 

--- a/shared/entropy_lab.py
+++ b/shared/entropy_lab.py
@@ -1,0 +1,72 @@
+import argparse
+import math
+import sys
+from collections import Counter
+from typing import Dict, Any, Union
+
+class EntropyLabManager:
+    """Manages Entropy calculations and analysis for data."""
+
+    def calculate_entropy(self, data: bytes) -> float:
+        """Calculates the Shannon entropy of the given byte data."""
+        if not data:
+            return 0.0
+        length = len(data)
+        counts = Counter(data)
+        entropy = -sum((count / length) * math.log2(count / length) for count in counts.values())
+        return entropy
+
+    def analyze_data(self, data: bytes) -> Dict[str, Any]:
+        """Analyzes data and provides entropy and heuristics."""
+        entropy = self.calculate_entropy(data)
+        length = len(data)
+
+        # Simple heuristics based on entropy and length
+        if length == 0:
+            assessment = "Empty data"
+        elif entropy < 3.0:
+            assessment = "Low entropy (highly repetitive or simple text)"
+        elif entropy < 5.0:
+            assessment = "Moderate entropy (typical English text or simple code)"
+        elif entropy < 7.0:
+            assessment = "High entropy (complex text, some compressed data)"
+        elif entropy >= 7.5:
+            assessment = "Very high entropy (likely compressed, encrypted, or random data)"
+        else:
+            assessment = "High entropy"
+
+        return {
+            "entropy": entropy,
+            "length": length,
+            "assessment": assessment
+        }
+
+
+def run_entropy_lab_logic(args: argparse.Namespace) -> bool:
+    """CLI logic for Entropy Lab."""
+    manager = EntropyLabManager()
+
+    data = None
+    if getattr(args, "text", None) is not None:
+        data = args.text.encode("utf-8")
+    elif getattr(args, "file", None) is not None:
+        try:
+            with open(args.file, "rb") as f:
+                data = f.read()
+        except Exception as e:
+            print(f"Error reading file: {e}", file=sys.stderr)
+            return False
+    elif not sys.stdin.isatty():
+        # Read from pipe
+        data = sys.stdin.buffer.read()
+
+    if data is None:
+        print("Error: Must provide --text, --file, or pipe data to stdin.", file=sys.stderr)
+        return False
+
+    result = manager.analyze_data(data)
+    print(f"Size: {result['length']} bytes")
+    print(f"Entropy: {result['entropy']:.4f} bits per byte")
+    print(f"Assessment: {result['assessment']}")
+
+    return True

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -78,6 +78,7 @@ from shared.tui_k8s import K8sTab
 from shared.tui_csv2sql import Csv2SqlTab
 from shared.tui_json2sql import Json2SqlTab
 from shared.tui_htpasswd import HtpasswdLabTab
+from shared.tui_entropy import EntropyLabTab
 from shared.tui_terraform import TerraformTab
 from shared.tui_presentation import PresentationTab
 from shared.tui_proc import ProcLabTab
@@ -4931,6 +4932,8 @@ class AgentTUI(App):
                 yield SizeLabTab()
             with TabPane("Hexdump Lab", id="tab-hexdump"):
                 yield HexdumpLabTab()
+            with TabPane("Entropy Lab", id="tab-entropy"):
+                yield EntropyLabTab()
 
             with TabPane("Unicode Lab", id="tab-uni"):
                 yield UniLabTab()

--- a/shared/tui_entropy.py
+++ b/shared/tui_entropy.py
@@ -1,0 +1,57 @@
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal, Vertical
+from textual.widgets import Label, TextArea, Button
+from textual import on
+
+from shared.entropy_lab import EntropyLabManager
+
+
+class EntropyLabTab(Container):
+    """Tab for Entropy Lab."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.manager = EntropyLabManager()
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label("[bold]Entropy Lab[/bold]", classes="welcome-text")
+
+            with Horizontal(classes="stat-box"):
+                yield Button("Analyze Text", id="btn-entropy-analyze", variant="primary")
+                yield Button("Clear", id="btn-entropy-clear", variant="warning")
+
+            with Horizontal():
+                with Vertical(classes="stat-box"):
+                    yield Label("[bold]Input Text[/bold]")
+                    yield TextArea(id="entropy-input-text")
+
+                with Vertical(classes="stat-box"):
+                    yield Label("[bold]Analysis Output[/bold]")
+                    yield TextArea(id="entropy-output-text", read_only=True)
+
+    @on(Button.Pressed)
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        input_area = self.query_one("#entropy-input-text", TextArea)
+        output_area = self.query_one("#entropy-output-text", TextArea)
+
+        if event.button.id == "btn-entropy-analyze":
+            text = input_area.text
+            if not text:
+                self.notify("Input required.", severity="error")
+                return
+
+            data = text.encode("utf-8")
+            result = self.manager.analyze_data(data)
+
+            output = f"Size: {result['length']} bytes\n"
+            output += f"Entropy: {result['entropy']:.4f} bits per byte\n"
+            output += f"Assessment: {result['assessment']}\n"
+
+            output_area.text = output
+            self.notify("Entropy analyzed.")
+
+        elif event.button.id == "btn-entropy-clear":
+            input_area.text = ""
+            output_area.text = ""
+            self.notify("Cleared.")

--- a/tests/test_entropy_lab.py
+++ b/tests/test_entropy_lab.py
@@ -1,0 +1,67 @@
+import unittest
+import argparse
+from unittest.mock import patch
+import io
+import os
+import tempfile
+from shared.entropy_lab import EntropyLabManager, run_entropy_lab_logic
+
+class TestEntropyLab(unittest.TestCase):
+    def setUp(self):
+        self.manager = EntropyLabManager()
+
+    def test_calculate_entropy(self):
+        # Empty data
+        self.assertEqual(self.manager.calculate_entropy(b""), 0.0)
+        # Single byte
+        self.assertEqual(self.manager.calculate_entropy(b"A" * 100), 0.0)
+        # Two alternating bytes (equal distribution)
+        self.assertEqual(self.manager.calculate_entropy(b"AB" * 50), 1.0)
+        # Random / Max Entropy for 256 bytes (0-255)
+        self.assertAlmostEqual(self.manager.calculate_entropy(bytes(range(256))), 8.0, places=4)
+
+    def test_analyze_data(self):
+        result = self.manager.analyze_data(b"A" * 100)
+        self.assertEqual(result["length"], 100)
+        self.assertEqual(result["entropy"], 0.0)
+        self.assertEqual(result["assessment"], "Low entropy (highly repetitive or simple text)")
+
+        result = self.manager.analyze_data(b"")
+        self.assertEqual(result["assessment"], "Empty data")
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_cli_text_args(self, mock_stdout):
+        args = argparse.Namespace(text="ABAB", file=None)
+        success = run_entropy_lab_logic(args)
+        self.assertTrue(success)
+        output = mock_stdout.getvalue()
+        self.assertIn("Size: 4 bytes", output)
+        self.assertIn("Entropy: 1.0000", output)
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    def test_cli_file_args(self, mock_stdout):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"ABAB")
+            temp_path = f.name
+
+        args = argparse.Namespace(text=None, file=temp_path)
+        try:
+            success = run_entropy_lab_logic(args)
+            self.assertTrue(success)
+            output = mock_stdout.getvalue()
+            self.assertIn("Size: 4 bytes", output)
+            self.assertIn("Entropy: 1.0000", output)
+        finally:
+            os.remove(temp_path)
+
+    @patch("sys.stderr", new_callable=io.StringIO)
+    def test_cli_missing_args(self, mock_stderr):
+        args = argparse.Namespace(text=None, file=None)
+        # patch isatty to True to simulate terminal (not pipe)
+        with patch("sys.stdin.isatty", return_value=True):
+            success = run_entropy_lab_logic(args)
+            self.assertFalse(success)
+            self.assertIn("Must provide --text, --file, or pipe data", mock_stderr.getvalue())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tui_entropy.py
+++ b/tests/test_tui_entropy.py
@@ -1,0 +1,40 @@
+import unittest
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).parent.parent))
+
+class TestEntropyLabTUI(unittest.IsolatedAsyncioTestCase):
+    async def test_tui_render_and_interact(self):
+        try:
+            from textual.app import App, ComposeResult
+            from shared.tui_entropy import EntropyLabTab
+
+            class DummyApp(App):
+                def compose(self) -> ComposeResult:
+                    yield EntropyLabTab()
+
+            app = DummyApp()
+            async with app.run_test(headless=True) as pilot:
+                tab = app.query_one(EntropyLabTab)
+                self.assertIsNotNone(tab)
+
+                input_area = app.query_one("#entropy-input-text")
+                output_area = app.query_one("#entropy-output-text")
+
+                # Test Analyze
+                input_area.text = "ABAB"
+                await pilot.click("#btn-entropy-analyze")
+
+                # Should be 4 bytes and 1.0 entropy
+                self.assertIn("Size: 4 bytes", output_area.text)
+                self.assertIn("Entropy: 1.0000", output_area.text)
+
+                # Test Clear
+                await pilot.click("#btn-entropy-clear")
+                self.assertEqual(input_area.text, "")
+                self.assertEqual(output_area.text, "")
+
+        except ImportError:
+            self.skipTest("Textual not installed")


### PR DESCRIPTION
Restores commands deleted from `KNOWN_COMMANDS` list and correctly applies the intended Entropy Lab feature without introducing syntax errors or dropping commands like `crypto-lab` and `json-lab`.

---
*PR created automatically by Jules for task [13578012112097906978](https://jules.google.com/task/13578012112097906978) started by @process-failed-successfully*