### PR TITLE
fix: clean up favicon lab test linting issues causing CI failures

### DIFF
--- a/shared/favicon_lab.py
+++ b/shared/favicon_lab.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 import json
 
+
 class FaviconManager:
     """Manages generation of web favicons."""
 
@@ -121,6 +122,7 @@ class FaviconManager:
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="manifest" href="/site.webmanifest">"""
         return snippet
+
 
 def run_favicon_lab_logic(args) -> bool:
     manager = FaviconManager(args.project_dir)

--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -1,12 +1,12 @@
 import pytest
 from pathlib import Path
 import tempfile
-import sys
 import argparse
+
+from shared.favicon_lab import FaviconManager, run_favicon_lab_logic
 
 Image = pytest.importorskip("PIL.Image")
 
-from shared.favicon_lab import FaviconManager, run_favicon_lab_logic
 
 def test_generate_favicons():
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -40,6 +40,7 @@ def test_generate_favicons():
             file_path = out_dir / file
             assert file_path.is_file()
 
+
 def test_generate_favicons_too_small():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
@@ -56,12 +57,14 @@ def test_generate_favicons_too_small():
         assert success is False
         assert not (tmp_path / "out_dir").exists()
 
+
 def test_generate_favicons_missing_file():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
         manager = FaviconManager(tmp_path)
         success = manager.generate("missing.png", "out_dir")
         assert success is False
+
 
 def test_html_snippet():
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -73,6 +76,7 @@ def test_html_snippet():
         assert "favicon-32x32.png" in html
         assert "favicon-16x16.png" in html
         assert "site.webmanifest" in html
+
 
 def test_run_favicon_lab_logic_generate(monkeypatch):
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -94,6 +98,7 @@ def test_run_favicon_lab_logic_generate(monkeypatch):
         assert success is True
         assert (tmp_path / "out" / "favicon.ico").is_file()
 
+
 def test_run_favicon_lab_logic_generate_missing_image():
     with tempfile.TemporaryDirectory() as tmpdir:
         args = argparse.Namespace(
@@ -104,6 +109,7 @@ def test_run_favicon_lab_logic_generate_missing_image():
         )
         success = run_favicon_lab_logic(args)
         assert success is False
+
 
 def test_run_favicon_lab_logic_html(capsys):
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_tui_favicon.py
+++ b/tests/test_tui_favicon.py
@@ -2,9 +2,10 @@ import pytest
 from pathlib import Path
 import tempfile
 
+from shared.tui import AgentTUI
+
 Image = pytest.importorskip("PIL.Image")
 
-from shared.tui import AgentTUI
 
 @pytest.fixture
 def temp_project_dir():
@@ -14,11 +15,12 @@ def temp_project_dir():
         init_db(path / ".agent_db.sqlite")
         yield path
 
+
 @pytest.mark.asyncio
 async def test_favicon_lab_tui_load_and_generate(temp_project_dir):
     app = AgentTUI(project_dir=temp_project_dir, start_tab="tab-favicon")
 
-    async with app.run_test(headless=True) as pilot:
+    async with app.run_test(headless=True):
         # Verify the tab loaded successfully
         assert app.query_one("#favicon-image-input") is not None
 
@@ -42,11 +44,12 @@ async def test_favicon_lab_tui_load_and_generate(temp_project_dir):
         html_output = str(app.query_one("#favicon-output").render())
         assert "apple-touch-icon" in html_output
 
+
 @pytest.mark.asyncio
 async def test_favicon_lab_tui_empty_input(temp_project_dir):
     app = AgentTUI(project_dir=temp_project_dir, start_tab="tab-favicon")
 
-    async with app.run_test(headless=True) as pilot:
+    async with app.run_test(headless=True):
         app.query_one("#favicon-image-input").value = ""
 
         tab = app.query_one("FaviconLabTab")
@@ -55,11 +58,12 @@ async def test_favicon_lab_tui_empty_input(temp_project_dir):
         output_text = str(app.query_one("#favicon-output").render())
         assert "Error: Source image path is required" in output_text
 
+
 @pytest.mark.asyncio
 async def test_favicon_lab_tui_invalid_image(temp_project_dir):
     app = AgentTUI(project_dir=temp_project_dir, start_tab="tab-favicon")
 
-    async with app.run_test(headless=True) as pilot:
+    async with app.run_test(headless=True):
         app.query_one("#favicon-image-input").value = "missing.png"
 
         tab = app.query_one("FaviconLabTab")


### PR DESCRIPTION
This PR cleans up several minor Flake8 violations in the Favicon Lab codebase that were resulting in failed static checks and breaking the CI pipeline.

It corrects import orders, removes unused variables, and standardizes spacing without modifying the core behavior.

---
*PR created automatically by Jules for task [5291038000380492815](https://jules.google.com/task/5291038000380492815) started by @process-failed-successfully*