### PR TITLE
feat: Add Cookie Lab CLI and TUI functionality

### DIFF
--- a/main.py
+++ b/main.py
@@ -264,6 +264,7 @@ KNOWN_COMMANDS = [
     "ical-lab", "ical", "ics",
     "markdown-lab", "md", "md-lab", "yaml-lab", "yaml", "ini-lab", "ini", "toml-lab", "toml", "net-lab", "net", "archive-lab", "arc",
     "plist-lab", "plist", "plist2json", "json2plist",
+    "cookie-lab", "cookie",
     "props-lab", "props", "properties",
     "run2compose-lab", "run2compose", "r2c",
     "compose2k8s-lab", "compose2k8s", "c2k",
@@ -9962,6 +9963,21 @@ def parse_args(argv=None):
 
     parser_validate = subparsers.add_parser("validate", help="Validate the agent_config.yaml file")
     parser_list_agents = subparsers.add_parser("list-agents", help="List available agents")
+
+    # Cookie Lab parser
+    parser_cookie = subparsers.add_parser("cookie-lab", aliases=["cookie"], help="Parse and generate HTTP Cookie and Set-Cookie headers.")
+    parser_cookie.add_argument("--tui", action="store_true", help="Launch the Cookie Lab TUI")
+    parser_cookie.add_argument("action", nargs="?", choices=["parse", "generate", "tui"], help="Action to perform")
+    parser_cookie.add_argument("--string", type=str, help="Cookie string to parse")
+    parser_cookie.add_argument("--key", type=str, help="Key for cookie generation")
+    parser_cookie.add_argument("--value", type=str, help="Value for cookie generation")
+    parser_cookie.add_argument("--domain", type=str, help="Domain for generated cookie")
+    parser_cookie.add_argument("--path", type=str, help="Path for generated cookie")
+    parser_cookie.add_argument("--expires", type=str, help="Expires string for generated cookie")
+    parser_cookie.add_argument("--max-age", type=int, help="Max-Age integer for generated cookie")
+    parser_cookie.add_argument("--secure", action="store_true", help="Set Secure flag for generated cookie")
+    parser_cookie.add_argument("--httponly", action="store_true", help="Set HttpOnly flag for generated cookie")
+    parser_cookie.add_argument("--samesite", type=str, choices=["Strict", "Lax", "None"], help="SameSite value for generated cookie")
 
     # Props Lab parser
     props_parser = subparsers.add_parser("props-lab", aliases=["props", "properties"], help="Convert Java .properties to/from JSON and YAML.")
@@ -21952,6 +21968,28 @@ def run_argon2_lab(args):
     sys.exit(0 if success else 1)
 
 
+def run_cookie_lab(args):
+    """Runs the Cookie Lab."""
+    if getattr(args, "action", None) == "tui" or getattr(args, "tui", False):
+        from shared.tui import AgentTUI
+        print("Launching Cookie Lab TUI...")
+        app = AgentTUI(project_dir=getattr(args, 'project_dir', None), start_tab="tab-cookie")
+        import asyncio
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop and loop.is_running():
+            asyncio.ensure_future(app.run_async())
+        else:
+            app.run()
+        sys.exit(0)
+
+    from shared.cookie_lab import run_cookie_lab_logic
+    success = run_cookie_lab_logic(args)
+    sys.exit(0 if success else 1)
+
+
 def run_currency_lab(args):
     """Runs the Currency Lab."""
     if getattr(args, 'tui', False):
@@ -24604,6 +24642,10 @@ async def main():
 
     if args.command in ["url-lab", "url"]:
         run_url_lab(args)
+        return
+
+    if args.command in ["cookie-lab", "cookie"]:
+        run_cookie_lab(args)
         return
 
     if args.command in ["urlencode-lab", "urlencode"]:

--- a/shared/cookie_lab.py
+++ b/shared/cookie_lab.py
@@ -1,0 +1,84 @@
+import sys
+import http.cookies
+import json
+
+
+class CookieLabManager:
+    """Manages parsing and generating HTTP Cookie headers."""
+
+    def parse_cookie(self, cookie_string: str) -> dict:
+        """Parses a Cookie or Set-Cookie string into a dictionary."""
+        cookie = http.cookies.SimpleCookie()
+        try:
+            cookie.load(cookie_string)
+        except http.cookies.CookieError as e:
+            return {"error": str(e)}
+
+        result = {}
+        for key, morsel in cookie.items():
+            morsel_dict = {"value": morsel.value}
+            # Add other attributes if they exist
+            for attr in ['expires', 'path', 'comment', 'domain', 'max-age', 'secure', 'httponly', 'version', 'samesite']:
+                if morsel[attr]:
+                    morsel_dict[attr] = morsel[attr]
+            result[key] = morsel_dict
+        return {"cookies": result}
+
+    def generate_cookie(self, key: str, value: str, **kwargs) -> dict:
+        """Generates a Set-Cookie string."""
+        cookie = http.cookies.SimpleCookie()
+        cookie[key] = value
+        morsel = cookie[key]
+
+        for attr, attr_value in kwargs.items():
+            if attr_value is not None:
+                morsel[attr] = attr_value
+
+        return {"set_cookie": morsel.OutputString()}
+
+
+def run_cookie_lab_logic(args) -> bool:
+    """CLI entry point for Cookie Lab logic."""
+    manager = CookieLabManager()
+
+    if getattr(args, "action", None) == "parse":
+        if not getattr(args, "string", None):
+            print("Error: --string is required for parsing.", file=sys.stderr)
+            return False
+
+        res = manager.parse_cookie(args.string)
+        if "error" in res:
+            print(f"Error parsing cookie: {res['error']}", file=sys.stderr)
+            return False
+
+        print(json.dumps(res, indent=2))
+        return True
+
+    elif getattr(args, "action", None) == "generate":
+        if not getattr(args, "key", None) or not getattr(args, "value", None):
+            print("Error: --key and --value are required for generation.", file=sys.stderr)
+            return False
+
+        kwargs = {}
+        if getattr(args, "domain", None):
+            kwargs["domain"] = args.domain
+        if getattr(args, "path", None):
+            kwargs["path"] = args.path
+        if getattr(args, "expires", None):
+            kwargs["expires"] = args.expires
+        if getattr(args, "max_age", None):
+            kwargs["max-age"] = args.max_age
+        if getattr(args, "secure", False):
+            kwargs["secure"] = True
+        if getattr(args, "httponly", False):
+            kwargs["httponly"] = True
+        if getattr(args, "samesite", None):
+            kwargs["samesite"] = args.samesite
+
+        res = manager.generate_cookie(args.key, args.value, **kwargs)
+        print(res["set_cookie"])
+        return True
+
+    else:
+        print("Error: Unknown action or missing arguments.", file=sys.stderr)
+        return False

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -127,6 +127,7 @@ from shared.tui_text import TextLabTab
 from shared.tui_time import TimeLabTab
 from shared.tui_date import DateLabTab
 from shared.tui_phonetic import PhoneticLabTab
+from shared.tui_cookie import CookieLabTab
 from shared.tui_jwt import JwtLabTab
 from shared.tui_math import MathLabTab
 from shared.tui_calc import CalcLabTab
@@ -4301,6 +4302,8 @@ class AgentTUI(App):
                 yield FlattenLabTab()
             with TabPane("Phonetic Lab", id="tab-phonetic"):
                 yield PhoneticLabTab(self.project_dir)
+            with TabPane("Cookie Lab", id="tab-cookie"):
+                yield CookieLabTab(self.project_dir)
             with TabPane("Static Lab", id="tab-static"):
                 yield StaticLabTab(project_dir=self.project_dir)
             with TabPane("Dashboard", id="tab-dashboard"):

--- a/shared/tui_cookie.py
+++ b/shared/tui_cookie.py
@@ -1,0 +1,104 @@
+import json
+from pathlib import Path
+from textual.app import ComposeResult
+from textual.containers import Horizontal, VerticalScroll, Vertical
+from textual.widgets import Label, Input, Button, Checkbox, TextArea, Select
+from textual import on
+from shared.cookie_lab import CookieLabManager
+
+
+class CookieLabTab(VerticalScroll):
+    """TUI tab for managing HTTP Cookies."""
+
+    def __init__(self, project_dir: Path | None = None, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.project_dir = project_dir
+        self.manager = CookieLabManager()
+
+    def compose(self) -> ComposeResult:
+        yield Label("[bold]Cookie Lab[/bold]", classes="welcome-text")
+
+        # Parser Section
+        with Vertical(classes="stat-box"):
+            yield Label("[bold]Parse Cookie[/bold]")
+            yield Label("Enter a raw Cookie or Set-Cookie header string:")
+            yield Input(placeholder="session_id=123; Path=/; Secure; HttpOnly", id="cookie-parse-input")
+            yield Button("Parse", id="btn-cookie-parse", variant="primary")
+            yield TextArea(id="cookie-parse-output", read_only=True, language="json")
+
+        # Generator Section
+        with Vertical(classes="stat-box"):
+            yield Label("[bold]Generate Set-Cookie[/bold]")
+            with Horizontal():
+                yield Input(placeholder="Key (e.g. session_id)", id="cookie-gen-key")
+                yield Input(placeholder="Value (e.g. 12345)", id="cookie-gen-value")
+
+            with Horizontal():
+                yield Input(placeholder="Domain (optional)", id="cookie-gen-domain")
+                yield Input(placeholder="Path (default: /)", id="cookie-gen-path", value="/")
+                yield Input(placeholder="Expires (optional)", id="cookie-gen-expires")
+
+            with Horizontal():
+                yield Input(placeholder="Max-Age (seconds, optional)", id="cookie-gen-max-age", type="integer")
+                yield Select.from_values(["Strict", "Lax", "None", ""], prompt="SameSite", id="cookie-gen-samesite")
+
+            with Horizontal():
+                yield Checkbox("Secure", id="cookie-gen-secure", value=False)
+                yield Checkbox("HttpOnly", id="cookie-gen-httponly", value=False)
+
+            yield Button("Generate", id="btn-cookie-generate", variant="warning")
+            yield Input(placeholder="Generated Set-Cookie string will appear here...", id="cookie-gen-output", read_only=True)
+
+    @on(Button.Pressed, "#btn-cookie-parse")
+    def on_parse(self, event: Button.Pressed) -> None:
+        cookie_string = self.query_one("#cookie-parse-input", Input).value
+        if not cookie_string:
+            self.notify("Please enter a cookie string to parse.", severity="warning")
+            return
+
+        res = self.manager.parse_cookie(cookie_string)
+        output = self.query_one("#cookie-parse-output", TextArea)
+
+        if "error" in res:
+            output.text = f"Error: {res['error']}"
+        else:
+            output.text = json.dumps(res, indent=2)
+
+    @on(Button.Pressed, "#btn-cookie-generate")
+    def on_generate(self, event: Button.Pressed) -> None:
+        key = self.query_one("#cookie-gen-key", Input).value
+        value = self.query_one("#cookie-gen-value", Input).value
+
+        if not key or not value:
+            self.notify("Key and Value are required.", severity="error")
+            return
+
+        kwargs = {}
+        domain = self.query_one("#cookie-gen-domain", Input).value
+        path = self.query_one("#cookie-gen-path", Input).value
+        expires = self.query_one("#cookie-gen-expires", Input).value
+        max_age = self.query_one("#cookie-gen-max-age", Input).value
+        samesite = self.query_one("#cookie-gen-samesite", Select).value
+        secure = self.query_one("#cookie-gen-secure", Checkbox).value
+        httponly = self.query_one("#cookie-gen-httponly", Checkbox).value
+
+        if domain:
+            kwargs["domain"] = domain
+        if path:
+            kwargs["path"] = path
+        if expires:
+            kwargs["expires"] = expires
+        if max_age:
+            kwargs["max-age"] = max_age
+        if samesite and samesite != Select.BLANK:
+            kwargs["samesite"] = samesite
+        if secure:
+            kwargs["secure"] = True
+        if httponly:
+            kwargs["httponly"] = True
+
+        try:
+            res = self.manager.generate_cookie(key, value, **kwargs)
+            self.query_one("#cookie-gen-output", Input).value = res["set_cookie"]
+        except Exception as e:
+            self.notify(f"Generation error: {str(e)}", severity="error")

--- a/tests/test_cookie_lab.py
+++ b/tests/test_cookie_lab.py
@@ -1,0 +1,63 @@
+import subprocess
+import sys
+import os
+from shared.cookie_lab import CookieLabManager
+
+
+def test_cookie_parse():
+    manager = CookieLabManager()
+
+    # Test valid parsing
+    res = manager.parse_cookie("session_id=12345; Path=/; Secure; HttpOnly; SameSite=Lax")
+    assert "error" not in res
+    assert "cookies" in res
+    assert "session_id" in res["cookies"]
+
+    morsel = res["cookies"]["session_id"]
+    assert morsel["value"] == "12345"
+    assert morsel["path"] == "/"
+    assert morsel["secure"] is True
+    assert morsel["httponly"] is True
+    assert morsel["samesite"] == "Lax"
+
+
+def test_cookie_generate():
+    manager = CookieLabManager()
+
+    # Test cookie generation
+    res = manager.generate_cookie("user_id", "abc", path="/app", secure=True, httponly=True)
+    assert "set_cookie" in res
+    output = res["set_cookie"]
+
+    assert "user_id=abc" in output
+    assert "Path=/app" in output
+    assert "Secure" in output
+    assert "HttpOnly" in output
+
+
+def test_cookie_lab_cli():
+    env = os.environ.copy()
+    if 'PYTHONPATH' in env:
+        env['PYTHONPATH'] = f".{os.pathsep}{env['PYTHONPATH']}"
+    else:
+        env['PYTHONPATH'] = "."
+
+    # Test parse via CLI
+    res = subprocess.run(
+        [sys.executable, "main.py", "cookie-lab", "parse", "--string", "test_key=test_val"],
+        env=env,
+        capture_output=True, text=True
+    )
+    assert res.returncode == 0
+    assert "test_key" in res.stdout
+    assert "test_val" in res.stdout
+
+    # Test generate via CLI
+    res2 = subprocess.run(
+        [sys.executable, "main.py", "cookie-lab", "generate", "--key", "session", "--value", "xyz", "--secure"],
+        env=env,
+        capture_output=True, text=True
+    )
+    assert res2.returncode == 0
+    assert "session=xyz" in res2.stdout
+    assert "Secure" in res2.stdout


### PR DESCRIPTION
This feature adds a new utility to the autonomous agent toolkit, the "Cookie Lab". It allows developers to quickly parse, inspect, and generate HTTP `Cookie` and `Set-Cookie` strings from both the command line (`cookie-lab parse`, `cookie-lab generate`) and via a dedicated Textual TUI tab. It has zero external dependencies since it relies on Python's native `http.cookies.SimpleCookie` module, and comes with full test coverage for CLI routing and string formatting logic.

---
*PR created automatically by Jules for task [6379222768092651705](https://jules.google.com/task/6379222768092651705) started by @process-failed-successfully*