### PR TITLE
fix: resolve flake8 linting errors in favicon tests

### DIFF
--- a/tests/test_favicon_lab.py
+++ b/tests/test_favicon_lab.py
@@ -1,12 +1,13 @@
 import pytest
 from pathlib import Path
 import tempfile
-import sys
+
 import argparse
 
 Image = pytest.importorskip("PIL.Image")
 
-from shared.favicon_lab import FaviconManager, run_favicon_lab_logic
+from shared.favicon_lab import FaviconManager, run_favicon_lab_logic  # noqa: E402
+
 
 def test_generate_favicons():
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -40,6 +41,7 @@ def test_generate_favicons():
             file_path = out_dir / file
             assert file_path.is_file()
 
+
 def test_generate_favicons_too_small():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
@@ -56,12 +58,14 @@ def test_generate_favicons_too_small():
         assert success is False
         assert not (tmp_path / "out_dir").exists()
 
+
 def test_generate_favicons_missing_file():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
         manager = FaviconManager(tmp_path)
         success = manager.generate("missing.png", "out_dir")
         assert success is False
+
 
 def test_html_snippet():
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -73,6 +77,7 @@ def test_html_snippet():
         assert "favicon-32x32.png" in html
         assert "favicon-16x16.png" in html
         assert "site.webmanifest" in html
+
 
 def test_run_favicon_lab_logic_generate(monkeypatch):
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -94,6 +99,7 @@ def test_run_favicon_lab_logic_generate(monkeypatch):
         assert success is True
         assert (tmp_path / "out" / "favicon.ico").is_file()
 
+
 def test_run_favicon_lab_logic_generate_missing_image():
     with tempfile.TemporaryDirectory() as tmpdir:
         args = argparse.Namespace(
@@ -104,6 +110,7 @@ def test_run_favicon_lab_logic_generate_missing_image():
         )
         success = run_favicon_lab_logic(args)
         assert success is False
+
 
 def test_run_favicon_lab_logic_html(capsys):
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_tui_favicon.py
+++ b/tests/test_tui_favicon.py
@@ -4,7 +4,8 @@ import tempfile
 
 Image = pytest.importorskip("PIL.Image")
 
-from shared.tui import AgentTUI
+from shared.tui import AgentTUI  # noqa: E402
+
 
 @pytest.fixture
 def temp_project_dir():
@@ -14,11 +15,12 @@ def temp_project_dir():
         init_db(path / ".agent_db.sqlite")
         yield path
 
+
 @pytest.mark.asyncio
 async def test_favicon_lab_tui_load_and_generate(temp_project_dir):
     app = AgentTUI(project_dir=temp_project_dir, start_tab="tab-favicon")
 
-    async with app.run_test(headless=True) as pilot:
+    async with app.run_test(headless=True):
         # Verify the tab loaded successfully
         assert app.query_one("#favicon-image-input") is not None
 
@@ -42,11 +44,12 @@ async def test_favicon_lab_tui_load_and_generate(temp_project_dir):
         html_output = str(app.query_one("#favicon-output").render())
         assert "apple-touch-icon" in html_output
 
+
 @pytest.mark.asyncio
 async def test_favicon_lab_tui_empty_input(temp_project_dir):
     app = AgentTUI(project_dir=temp_project_dir, start_tab="tab-favicon")
 
-    async with app.run_test(headless=True) as pilot:
+    async with app.run_test(headless=True):
         app.query_one("#favicon-image-input").value = ""
 
         tab = app.query_one("FaviconLabTab")
@@ -55,11 +58,12 @@ async def test_favicon_lab_tui_empty_input(temp_project_dir):
         output_text = str(app.query_one("#favicon-output").render())
         assert "Error: Source image path is required" in output_text
 
+
 @pytest.mark.asyncio
 async def test_favicon_lab_tui_invalid_image(temp_project_dir):
     app = AgentTUI(project_dir=temp_project_dir, start_tab="tab-favicon")
 
-    async with app.run_test(headless=True) as pilot:
+    async with app.run_test(headless=True):
         app.query_one("#favicon-image-input").value = "missing.png"
 
         tab = app.query_one("FaviconLabTab")


### PR DESCRIPTION
Resolved flake8 errors in `tests/test_favicon_lab.py` and `tests/test_tui_favicon.py` to fix the CI failure.

*   Fixed `E402` (module level import not at top of file) by correctly moving test-specific imports below the `pytest.importorskip("PIL.Image")` directive and appending `# noqa: E402`.
*   Fixed `F401` by removing an unused `import sys`.
*   Fixed `F841` (local variable assigned but never used) by replacing `async with app.run_test(headless=True) as pilot:` with `async with app.run_test(headless=True):`.
*   Fixed `E302` and formatting issues using `autopep8`.

---
*PR created automatically by Jules for task [6343180958000947231](https://jules.google.com/task/6343180958000947231) started by @process-failed-successfully*