### PR TITLE
feat: add CookieLab for parsing and generating HTTP cookies

### DIFF
--- a/main.py
+++ b/main.py
@@ -357,6 +357,7 @@ KNOWN_COMMANDS = [
     "base64url-lab", "base64url", "b64url",
     "zlib-lab", "zlib", "compress", "inflate",
     "brotli-lab", "brotli", "zstd-lab", "zstd",
+    "cookie-lab", "cookie",
     "base85-lab", "base85", "b85",
     "base91-lab", "base91", "b91",
     "base92-lab", "base92", "b92",
@@ -18027,7 +18028,22 @@ Examples:
     parser_bcrypt.add_argument("--rounds", type=int, default=12, help="Cost factor (rounds) for hashing (default: 12).")
     parser_bcrypt.add_argument("--hash-value", type=str, help="Hash string to verify against (required if using --verify).")
 
-    # brotli-lab
+
+    # cookie-lab
+    parser_cookie = subparsers.add_parser(
+        "cookie-lab", aliases=["cookie"],
+        help="Parse and generate HTTP Cookie strings."
+    )
+    cookie_subparsers = parser_cookie.add_subparsers(dest="action", required=True)
+
+    parser_cookie_parse = cookie_subparsers.add_parser("parse", help="Parse a raw Cookie string.")
+    parser_cookie_parse.add_argument("--cookie", type=str, required=True, help="Raw cookie string to parse.")
+
+    parser_cookie_generate = cookie_subparsers.add_parser("generate", help="Generate Set-Cookie strings.")
+    parser_cookie_generate.add_argument("--json", type=str, required=True, help="JSON array of cookie objects.")
+
+    parser_cookie_tui = cookie_subparsers.add_parser("tui", help="Launch interactive Cookie Lab TUI.")
+# brotli-lab
     parser_brotli = subparsers.add_parser(
         "brotli-lab", aliases=["brotli"],
         help="Compress and decompress data using Brotli."
@@ -24282,6 +24298,27 @@ async def main():
         if success:
             sys.exit(0)
         sys.exit(1)
+
+    if args.command in ["cookie-lab", "cookie"]:
+        if getattr(args, "action", None) == "tui" or getattr(args, "tui", False):
+            from shared.tui import AgentTUI
+            print("Launching Cookie Lab TUI...")
+            app = AgentTUI(project_dir=getattr(args, 'project_dir', Path(".")), start_tab="tab-cookie")
+            import asyncio
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+            if loop and loop.is_running():
+                asyncio.ensure_future(app.run_async())
+            else:
+                app.run()
+                sys.exit(0)
+            return
+
+        from shared.cookie_lab import run_cookie_lab_logic
+        success = run_cookie_lab_logic(args)
+        sys.exit(0 if success else 1)
 
     if args.command in ["browser-lab", "browser", "web"]:
         await run_browser_lab(args)

--- a/shared/cookie_lab.py
+++ b/shared/cookie_lab.py
@@ -1,0 +1,92 @@
+import sys
+import json
+from http.cookies import SimpleCookie
+
+
+class CookieLabManager:
+    """Manages Cookie parsing and generation operations."""
+
+    def parse(self, cookie_string: str) -> list:
+        """Parses a raw Cookie or Set-Cookie header into structured data."""
+        # SimpleCookie handles both "Cookie" (multiple key=value separated by semicolon)
+        # and "Set-Cookie" format well enough, though "Set-Cookie" usually comes one per line.
+
+        cookie = SimpleCookie()
+        try:
+            cookie.load(cookie_string)
+        except Exception as e:
+            return [{"error": str(e)}]
+
+        parsed = []
+        for key, morsel in cookie.items():
+            entry = {
+                "name": key,
+                "value": morsel.value,
+            }
+            # Add standard attributes if present
+            for attr in ["domain", "path", "expires", "max-age", "secure", "httponly", "samesite"]:
+                if morsel[attr]:
+                    entry[attr] = morsel[attr]
+            parsed.append(entry)
+
+        return parsed
+
+    def generate(self, cookie_data: list) -> list:
+        """Generates Set-Cookie header strings from a list of structured dictionaries."""
+        results = []
+        for c_data in cookie_data:
+            if "name" not in c_data or "value" not in c_data:
+                continue
+
+            cookie = SimpleCookie()
+            name = c_data["name"]
+            value = c_data["value"]
+            cookie[name] = value
+            morsel = cookie[name]
+
+            for attr in ["domain", "path", "expires", "secure", "httponly", "samesite"]:
+                if attr in c_data:
+                    # 'secure' and 'httponly' should be empty string or True-like in SimpleCookie
+                    # but SimpleCookie accepts boolean if we convert it appropriately or just string
+                    if attr in ("secure", "httponly"):
+                        if str(c_data[attr]).lower() in ("true", "1", "yes"):
+                            morsel[attr] = True
+                    else:
+                        morsel[attr] = str(c_data[attr])
+
+            # SimpleCookie output is 'Set-Cookie: name=value; ...'
+            results.append(cookie.output(header="").strip())
+        return results
+
+
+def run_cookie_lab_logic(args) -> bool:
+    """CLI logic for the Cookie Lab."""
+    manager = CookieLabManager()
+
+    if args.action == "parse":
+        if getattr(args, "cookie", None):
+            res = manager.parse(args.cookie)
+            print(json.dumps(res, indent=2))
+            return True
+        else:
+            print("Error: --cookie string required.", file=sys.stderr)
+            return False
+
+    elif args.action == "generate":
+        if getattr(args, "json", None):
+            try:
+                data = json.loads(args.json)
+                if isinstance(data, dict):
+                    data = [data]
+                res = manager.generate(data)
+                for r in res:
+                    print(r)
+                return True
+            except Exception as e:
+                print(f"Error generating cookie: {e}", file=sys.stderr)
+                return False
+        else:
+            print("Error: --json required.", file=sys.stderr)
+            return False
+
+    return False

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -77,6 +77,7 @@ from shared.tui_docker import DockerTab
 from shared.tui_k8s import K8sTab
 from shared.tui_csv2sql import Csv2SqlTab
 from shared.tui_json2sql import Json2SqlTab
+from shared.tui_cookie import CookieLabTab
 from shared.tui_htpasswd import HtpasswdLabTab
 from shared.tui_entropy import EntropyLabTab
 from shared.tui_terraform import TerraformTab
@@ -4323,6 +4324,8 @@ class AgentTUI(App):
                 yield PasswordLabTab()
             with TabPane("Systemd", id="tab-systemd"):
                 yield SystemdLabTab(self.project_dir)
+            with TabPane("Cookie Lab", id="tab-cookie"):
+                yield CookieLabTab(project_dir=self.project_dir)
             with TabPane("Port Lab", id="tab-ports"):
                 yield PortLabTab()
             with TabPane("Roman Lab", id="tab-roman"):

--- a/shared/tui_cookie.py
+++ b/shared/tui_cookie.py
@@ -1,0 +1,100 @@
+import json
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll, Horizontal, Vertical
+from textual.widgets import Button, Input, Label, TextArea, DataTable
+from shared.cookie_lab import CookieLabManager
+
+
+class CookieLabTab(VerticalScroll):
+    """TUI Tab for Cookie Lab operations."""
+
+    def __init__(self, project_dir=None, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.project_dir = project_dir
+        self.manager = CookieLabManager()
+
+    def compose(self) -> ComposeResult:
+        yield Label("Cookie Lab", classes="header-label")
+
+        with Vertical(classes="panel"):
+            yield Label("Parse Cookie", classes="section-label")
+            yield Input(placeholder="Enter raw Cookie or Set-Cookie header string", id="cl-cookie-input")
+            with Horizontal():
+                yield Button("Parse", id="btn-cl-parse", variant="primary")
+                yield Button("Clear", id="btn-cl-clear-parse", variant="error")
+
+            # Using DataTable for parsed results
+            yield DataTable(id="cl-parsed-table")
+
+        with Vertical(classes="panel"):
+            yield Label("Generate Cookie", classes="section-label")
+            yield Label("Enter JSON array of cookie objects:")
+            yield TextArea(
+                text='[\n  {\n    "name": "session_id",\n    "value": "123456",\n    "domain": "example.com",\n    "path": "/",\n    "secure": true,\n    "httponly": true\n  }\n]',
+                id="cl-json-input",
+                language="json"
+            )
+            with Horizontal():
+                yield Button("Generate", id="btn-cl-generate", variant="primary")
+                yield Button("Clear", id="btn-cl-clear-gen", variant="error")
+            yield TextArea(id="cl-gen-output", read_only=True)
+
+    def on_mount(self) -> None:
+        table = self.query_one("#cl-parsed-table", DataTable)
+        table.add_columns("Property", "Value")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        button_id = event.button.id
+
+        if button_id == "btn-cl-parse":
+            self.do_parse()
+        elif button_id == "btn-cl-clear-parse":
+            self.query_one("#cl-cookie-input", Input).value = ""
+            table = self.query_one("#cl-parsed-table", DataTable)
+            table.clear()
+        elif button_id == "btn-cl-generate":
+            self.do_generate()
+        elif button_id == "btn-cl-clear-gen":
+            self.query_one("#cl-gen-output", TextArea).text = ""
+
+    def do_parse(self) -> None:
+        cookie_str = self.query_one("#cl-cookie-input", Input).value.strip()
+        table = self.query_one("#cl-parsed-table", DataTable)
+        table.clear()
+
+        if not cookie_str:
+            table.add_row("Error", "Please enter a cookie string.")
+            return
+
+        parsed = self.manager.parse(cookie_str)
+        if not parsed:
+            table.add_row("Info", "No valid cookies found.")
+            return
+
+        if "error" in parsed[0]:
+            table.add_row("Error", parsed[0]["error"])
+            return
+
+        for i, c in enumerate(parsed):
+            table.add_row(f"--- Cookie {i+1} ---", "")
+            for k, v in c.items():
+                table.add_row(k, str(v))
+
+    def do_generate(self) -> None:
+        json_str = self.query_one("#cl-json-input", TextArea).text.strip()
+        out_area = self.query_one("#cl-gen-output", TextArea)
+        out_area.text = ""
+
+        if not json_str:
+            out_area.text = "Error: Input JSON is empty."
+            return
+
+        try:
+            data = json.loads(json_str)
+            if isinstance(data, dict):
+                data = [data]
+
+            results = self.manager.generate(data)
+            out_area.text = "\n".join(results)
+        except Exception as e:
+            out_area.text = f"Error generating cookie: {str(e)}"

--- a/tests/test_cookie_lab.py
+++ b/tests/test_cookie_lab.py
@@ -1,0 +1,62 @@
+from shared.cookie_lab import CookieLabManager
+import json
+import argparse
+from shared.cookie_lab import run_cookie_lab_logic
+
+
+class TestCookieLab:
+    def setup_method(self):
+        self.manager = CookieLabManager()
+
+    def test_parse_cookie(self):
+        cookie_str = 'session_id=12345; Domain=example.com; Path=/; Secure; HttpOnly'
+        parsed = self.manager.parse(cookie_str)
+        assert len(parsed) == 1
+        c = parsed[0]
+        assert c["name"] == "session_id"
+        assert c["value"] == "12345"
+        assert c["domain"] == "example.com"
+        assert c["path"] == "/"
+        assert c["secure"] is True or str(c["secure"]).lower() in ["true", "1", "yes"]
+        assert c["httponly"] is True or str(c["httponly"]).lower() in ["true", "1", "yes"]
+
+    def test_generate_cookie(self):
+        data = [{
+            "name": "test_cookie",
+            "value": "abc",
+            "domain": ".test.com",
+            "path": "/test",
+            "secure": True,
+            "httponly": True
+        }]
+        result = self.manager.generate(data)
+        assert len(result) == 1
+        s = result[0]
+        assert "test_cookie=abc" in s
+        assert "Domain=.test.com" in s
+        assert "Path=/test" in s
+        assert "Secure" in s
+        assert "HttpOnly" in s
+
+    def test_parse_invalid(self):
+        # A weird string that might not be a valid cookie shouldn't crash, but return gracefully
+        parsed = self.manager.parse("")
+        assert len(parsed) == 0
+
+    def test_cli_parse(self, capsys):
+        args = argparse.Namespace(action="parse", cookie="a=b; Domain=c.com")
+        res = run_cookie_lab_logic(args)
+        assert res is True
+        captured = capsys.readouterr()
+        out = captured.out
+        assert "a" in out
+        assert "b" in out
+        assert "c.com" in out
+
+    def test_cli_generate(self, capsys):
+        data = [{"name": "foo", "value": "bar"}]
+        args = argparse.Namespace(action="generate", json=json.dumps(data))
+        res = run_cookie_lab_logic(args)
+        assert res is True
+        captured = capsys.readouterr()
+        assert "foo=bar" in captured.out


### PR DESCRIPTION
This pull request introduces the `cookie-lab` functionality, providing both a CLI and an interactive TUI to easily parse existing HTTP cookie headers (or individual cookies) into JSON representations, and generate standard `Set-Cookie` header strings from JSON data. This fills a missing utility related to common web debugging and security tasks.

It uses Python's standard `http.cookies.SimpleCookie` module, ensuring dependency-free operation. Comprehensive unit tests and integration with `main.py` and `AgentTUI` are included.

---
*PR created automatically by Jules for task [5858734390350313880](https://jules.google.com/task/5858734390350313880) started by @process-failed-successfully*