### PR TITLE
feat: add string distance calculation to text-lab

### DIFF
--- a/main.py
+++ b/main.py
@@ -15082,6 +15082,12 @@ def parse_args(argv=None):
     parser_tl_random.add_argument("--charset", "-c", choices=["alphanumeric", "alpha", "numeric", "hex",
                                   "ascii"], default="alphanumeric", help="Character set to use (default: alphanumeric).")
 
+    # text-lab distance
+    parser_tl_distance = text_lab_subparsers.add_parser("distance", help="Calculate string distance.")
+    parser_tl_distance.add_argument("text1", help="First text.")
+    parser_tl_distance.add_argument("text2", help="Second text.")
+    parser_tl_distance.add_argument("--algo", "-a", choices=["levenshtein"], default="levenshtein", help="Distance algorithm.")
+
     text_lab_subparsers.add_parser("tui", help="Launch the Text Lab TUI.")
 
     # --- New 'html-entity-lab' command ---

--- a/shared/text_lab.py
+++ b/shared/text_lab.py
@@ -239,6 +239,28 @@ class TextLabManager:
         )
         return "\n".join(diff)
 
+    def distance(self, text1: str, text2: str, algo: str = "levenshtein") -> int:
+        algo = algo.lower()
+        if algo == "levenshtein":
+            m, n = len(text1), len(text2)
+            dp = [[0] * (n + 1) for _ in range(m + 1)]
+
+            for i in range(m + 1):
+                for j in range(n + 1):
+                    if i == 0:
+                        dp[i][j] = j
+                    elif j == 0:
+                        dp[i][j] = i
+                    elif text1[i - 1] == text2[j - 1]:
+                        dp[i][j] = dp[i - 1][j - 1]
+                    else:
+                        dp[i][j] = 1 + min(dp[i][j - 1],      # Insert
+                                           dp[i - 1][j],      # Remove
+                                           dp[i - 1][j - 1])  # Replace
+            return dp[m][n]
+        else:
+            raise ValueError(f"Unknown distance algorithm: {algo}")
+
     def _to_camel(self, text: str) -> str:
         # split by space, underscore, hyphen
         words = re.split(r'[\s_\-]+', text)
@@ -477,5 +499,14 @@ def run_text_lab_logic(args):
             print(f"Error: {e}", file=sys.stderr)
             return False
 
+    elif args.action == "distance":
+        if args.text1 is None or args.text2 is None:
+            print("Error: Two text inputs required for distance.", file=sys.stderr)
+            return False
+        try:
+            print(manager.distance(args.text1, args.text2, getattr(args, 'algo', 'levenshtein')))
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return False
 
     return True

--- a/tests/test_text_lab.py
+++ b/tests/test_text_lab.py
@@ -178,6 +178,16 @@ class TestTextLab(unittest.TestCase):
         self.assertIn("-bar", diff)
         self.assertIn("+baz", diff)
 
+    def test_distance_levenshtein(self):
+        self.assertEqual(self.manager.distance("kitten", "sitting", "levenshtein"), 3)
+        self.assertEqual(self.manager.distance("flaw", "lawn", "levenshtein"), 2)
+        self.assertEqual(self.manager.distance("", "abc", "levenshtein"), 3)
+        self.assertEqual(self.manager.distance("abc", "", "levenshtein"), 3)
+        self.assertEqual(self.manager.distance("abc", "abc", "levenshtein"), 0)
+
+        with self.assertRaises(ValueError):
+            self.manager.distance("a", "b", "unknown_algo")
+
     def test_hash_text(self):
         text = "hello"
         md5_hash = self.manager.hash_text(text, "md5")


### PR DESCRIPTION
Added a new `distance` subcommand to the `text-lab` tool to calculate the edit distance between two strings (currently supporting Levenshtein distance). It provides a useful text processing feature and is thoroughly tested.

---
*PR created automatically by Jules for task [8341238237976012172](https://jules.google.com/task/8341238237976012172) started by @process-failed-successfully*