### PR TITLE
feat(crypto-lab): add PBKDF2 key derivation support

### DIFF
--- a/main.py
+++ b/main.py
@@ -16736,6 +16736,14 @@ def parse_args(argv=None):
     parser_crypto_hash.add_argument("--file", help="Input file.")
     parser_crypto_hash.add_argument("--algo", default="sha256", help="Algorithm (md5, sha1, sha256, sha512).")
 
+    # crypto-lab pbkdf2
+    parser_crypto_pbkdf2 = crypto_subparsers.add_parser("pbkdf2", help="Derive key using PBKDF2.")
+    parser_crypto_pbkdf2.add_argument("--password", help="Password string.")
+    parser_crypto_pbkdf2.add_argument("--salt", help="Salt string.")
+    parser_crypto_pbkdf2.add_argument("--algo", default="sha256", help="Algorithm (md5, sha1, sha256, sha512).")
+    parser_crypto_pbkdf2.add_argument("--iterations", type=int, default=100000, help="Number of iterations.")
+    parser_crypto_pbkdf2.add_argument("--dklen", type=int, default=32, help="Derived key length.")
+
     # crypto-lab hmac
     parser_crypto_hmac = crypto_subparsers.add_parser("hmac", help="Calculate HMAC.")
     parser_crypto_hmac.add_argument("--text", help="Input text.")

--- a/shared/crypto_lab.py
+++ b/shared/crypto_lab.py
@@ -39,6 +39,29 @@ class CryptoLabManager:
         hasher.update(data_bytes)
         return hasher.hexdigest()
 
+    def pbkdf2_hmac(self, password: Union[str, bytes], salt: Union[str, bytes], algo: str = "sha256", iterations: int = 100000, dklen: int = 32) -> str:
+        """
+        Derives a key from a password and salt using PBKDF2-HMAC.
+        Supported algorithms: md5, sha1, sha256, sha512.
+        """
+        if isinstance(password, str):
+            password_bytes = password.encode("utf-8")
+        else:
+            password_bytes = password
+
+        if isinstance(salt, str):
+            salt_bytes = salt.encode("utf-8")
+        else:
+            salt_bytes = salt
+
+        algo = algo.lower()
+        if algo not in hashlib.algorithms_available:
+            if algo not in ["md5", "sha1", "sha256", "sha512"]:
+                raise ValueError(f"Unsupported algorithm: {algo}")
+
+        derived_key = hashlib.pbkdf2_hmac(algo, password_bytes, salt_bytes, iterations, dklen)
+        return derived_key.hex()
+
     def hmac_data(self, input_data: Union[str, bytes], key: Union[str, bytes], algo: str = "sha256") -> str:
         """
         Calculates the HMAC digest of the input data using the specified key.
@@ -229,6 +252,22 @@ def run_crypto_lab_logic(args) -> bool:
             result = manager.hash_data(data, args.algo)
             print(result)
             return True
+
+        elif args.action == "pbkdf2":
+            password = args.password
+            salt = args.salt
+
+            if not password or not salt:
+                print("Error: Password and Salt required.", file=sys.stderr)
+                return False
+
+            try:
+                result = manager.pbkdf2_hmac(password, salt, args.algo, args.iterations, args.dklen)
+                print(result)
+                return True
+            except Exception as e:
+                print(f"Error during PBKDF2: {e}", file=sys.stderr)
+                return False
 
         elif args.action == "hmac":
             data = None

--- a/shared/tui_crypto.py
+++ b/shared/tui_crypto.py
@@ -29,6 +29,28 @@ class CryptoLabTab(Container):
                         yield Label("[bold]Hash Output[/bold]")
                         yield TextArea(id="crypto-hash-output", read_only=True)
 
+                # PBKDF2
+                with TabPane("PBKDF2"):
+                    with Vertical(classes="stat-box"):
+                        yield Label("Password:")
+                        yield Input(id="crypto-pbkdf2-password", password=True)
+                        yield Label("Salt:")
+                        yield Input(id="crypto-pbkdf2-salt")
+                        yield Label("Algorithm:")
+                        yield Select.from_values(["md5", "sha1", "sha256", "sha512"], id="crypto-pbkdf2-algo", value="sha256")
+                        with Horizontal():
+                            with Vertical():
+                                yield Label("Iterations:")
+                                yield Input(value="100000", id="crypto-pbkdf2-iterations", type="integer")
+                            with Vertical():
+                                yield Label("Derived Key Length:")
+                                yield Input(value="32", id="crypto-pbkdf2-dklen", type="integer")
+                        yield Button("Derive Key", id="btn-crypto-pbkdf2", variant="primary")
+
+                    with Vertical(classes="stat-box"):
+                        yield Label("[bold]Derived Key Output (Hex)[/bold]")
+                        yield TextArea(id="crypto-pbkdf2-output", read_only=True)
+
                 # HMAC
                 with TabPane("HMAC"):
                     with Vertical(classes="stat-box"):
@@ -125,6 +147,8 @@ class CryptoLabTab(Container):
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "btn-crypto-hash":
             self.do_hash()
+        elif event.button.id == "btn-crypto-pbkdf2":
+            self.do_pbkdf2()
         elif event.button.id == "btn-crypto-hmac":
             self.do_hmac()
         elif event.button.id == "btn-crypto-gen-key":
@@ -159,6 +183,27 @@ class CryptoLabTab(Container):
             res = self.manager.hash_data(text, str(algo))
             out.text = res
             self.notify("Hash calculated.")
+        except Exception as e:
+            self.notify(f"Error: {e}", severity="error")
+
+    def do_pbkdf2(self) -> None:
+        password = self.query_one("#crypto-pbkdf2-password", Input).value
+        salt = self.query_one("#crypto-pbkdf2-salt", Input).value
+        algo = self.query_one("#crypto-pbkdf2-algo", Select).value or "sha256"
+        iters_str = self.query_one("#crypto-pbkdf2-iterations", Input).value
+        dklen_str = self.query_one("#crypto-pbkdf2-dklen", Input).value
+        out = self.query_one("#crypto-pbkdf2-output", TextArea)
+
+        if not password or not salt:
+            self.notify("Password and Salt required.", severity="error")
+            return
+
+        try:
+            iterations = int(iters_str) if iters_str else 100000
+            dklen = int(dklen_str) if dklen_str else 32
+            res = self.manager.pbkdf2_hmac(password, salt, str(algo), iterations, dklen)
+            out.text = res
+            self.notify("PBKDF2 key derived.")
         except Exception as e:
             self.notify(f"Error: {e}", severity="error")
 

--- a/tests/test_crypto_lab.py
+++ b/tests/test_crypto_lab.py
@@ -22,6 +22,17 @@ def test_hash_data(crypto_manager):
     # Test Bytes
     assert crypto_manager.hash_data(b"hello world", "sha256") == expected
 
+def test_pbkdf2_hmac(crypto_manager):
+    password = "secret_password"
+    salt = "salty_salt"
+
+    # Pre-calculated PBKDF2 hash using pbkdf2_hmac('sha256', b'secret_password', b'salty_salt', 100000, 32).hex()
+    expected = "7d9b0ca692ff57bae7513128a694833020d402c112face31e0a2849867175575"
+    assert crypto_manager.pbkdf2_hmac(password, salt, "sha256", 100000, 32) == expected
+
+    # Test Bytes
+    assert crypto_manager.pbkdf2_hmac(b"secret_password", b"salty_salt", "sha256", 100000, 32) == expected
+
 def test_hmac_data(crypto_manager):
     input_data = "hello world"
     key = "secret"
@@ -79,6 +90,20 @@ def test_cli_hash(capsys):
     run_crypto_lab_logic(args)
     captured = capsys.readouterr()
     assert "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08" in captured.out
+
+def test_cli_pbkdf2(capsys):
+    args = MagicMock()
+    args.action = "pbkdf2"
+    args.password = "secret"
+    args.salt = "salty"
+    args.algo = "sha256"
+    args.iterations = 100000
+    args.dklen = 32
+
+    run_crypto_lab_logic(args)
+    captured = capsys.readouterr()
+    expected_hash = "2ae5b47935dccabaf61792f4394bd046d085e128ab64400f80dcb4c1364bb85c"
+    assert expected_hash in captured.out
 
 def test_cli_hmac(capsys):
     args = MagicMock()


### PR DESCRIPTION
This pull request adds PBKDF2 (Password-Based Key Derivation Function 2) support to the Crypto Lab. It implements the underlying `pbkdf2_hmac` derivation logic in `CryptoLabManager`, exposing it to users via the `crypto-lab pbkdf2` CLI subcommand and as a new "PBKDF2" tab inside the Crypto Lab's interactive TUI (`tui_crypto.py`). This feature allows developers to derive secure cryptographic keys from passwords directly within the agent toolset. Full unit test coverage is included.

---
*PR created automatically by Jules for task [10618930299090154029](https://jules.google.com/task/10618930299090154029) started by @process-failed-successfully*