### PR TITLE
feat: add toml2py lab

### DIFF
--- a/main.py
+++ b/main.py
@@ -261,7 +261,7 @@ KNOWN_COMMANDS = [
     "favicon-lab", "favicon",
     "msgpack-lab", "msgpack", "mpack",
     "bson-lab", "bson",
-    "csv-lab", "csv", "csv2sql-lab", "csv2sql", "c2s", "json2sql-lab", "json2sql", "j2s", "csv2html-lab", "csv2html", "c2h", "json2csv-lab", "j2c", "json2ini-lab", "json2ini", "j2i", "csv2json-lab", "c2j", "csv2yaml-lab", "csv2yaml", "c2y", "env2json-lab", "env2json", "json2env", "json2md-lab", "json2md", "csv2md-lab", "csv2md", "md2csv-lab", "md2csv", "m2c", "csv2toml-lab", "csv2toml", "c2t", "yaml2csv-lab", "yaml2csv", "y2c", "xml2csv-lab", "xml2csv", "x2c", "toml2csv-lab", "toml2csv", "t2c", "yaml2json-lab", "yaml2json", "y2j", "json2py-lab", "json2py", "j2py", "json2yaml-lab", "json2yaml", "j2y", "yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t", "xml2toml-lab", "xml2toml", "toml2xml", "x2t", "json2toml-lab", "json2toml", "j2t", "xml2yaml-lab", "xml2yaml", "x2y", "yaml2xml-lab", "yaml2xml", "y2x", "yaml2py-lab", "yaml2py", "y2py", "json2ts-lab", "json2ts", "j2ts", "json2go-lab", "json2go", "j2go", "json2dart-lab", "json2dart", "j2dart", "json2swift-lab", "json2swift", "j2swift", "json2csharp-lab", "json2csharp", "j2cs", "json2rust-lab", "json2rust", "j2rs", "excel-lab", "xls", "xlsx", "excel", "template-lab", "tpl", "image-lab", "img", "exif-lab", "exif", "ocr-lab", "ocr", "media-lab", "media", "xml-lab", "xml", "lorem-lab", "lorem", "lipsum", "bip39-lab", "bip39", "magic-decode-lab", "magic-decode", "mdecode", "endian-lab", "endian", "entropy-lab", "entropy",
+    "csv-lab", "csv", "csv2sql-lab", "csv2sql", "c2s", "json2sql-lab", "json2sql", "j2s", "csv2html-lab", "csv2html", "c2h", "json2csv-lab", "j2c", "json2ini-lab", "json2ini", "j2i", "csv2json-lab", "c2j", "csv2yaml-lab", "csv2yaml", "c2y", "env2json-lab", "env2json", "json2env", "json2md-lab", "json2md", "csv2md-lab", "csv2md", "md2csv-lab", "md2csv", "m2c", "csv2toml-lab", "csv2toml", "c2t", "yaml2csv-lab", "yaml2csv", "y2c", "xml2csv-lab", "xml2csv", "x2c", "toml2csv-lab", "toml2csv", "t2c", "yaml2json-lab", "yaml2json", "y2j", "json2py-lab", "json2py", "j2py", "toml2py-lab", "toml2py", "t2py", "json2yaml-lab", "json2yaml", "j2y", "yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t", "xml2toml-lab", "xml2toml", "toml2xml", "x2t", "json2toml-lab", "json2toml", "j2t", "xml2yaml-lab", "xml2yaml", "x2y", "yaml2xml-lab", "yaml2xml", "y2x", "yaml2py-lab", "yaml2py", "y2py", "json2ts-lab", "json2ts", "j2ts", "json2go-lab", "json2go", "j2go", "json2dart-lab", "json2dart", "j2dart", "json2swift-lab", "json2swift", "j2swift", "json2csharp-lab", "json2csharp", "j2cs", "json2rust-lab", "json2rust", "j2rs", "excel-lab", "xls", "xlsx", "excel", "template-lab", "tpl", "image-lab", "img", "exif-lab", "exif", "ocr-lab", "ocr", "media-lab", "media", "xml-lab", "xml", "lorem-lab", "lorem", "lipsum", "bip39-lab", "bip39", "magic-decode-lab", "magic-decode", "mdecode", "endian-lab", "endian", "entropy-lab", "entropy",
     "ical-lab", "ical", "ics",
     "markdown-lab", "md", "md-lab", "yaml-lab", "yaml", "ini-lab", "ini", "toml-lab", "toml", "net-lab", "net", "archive-lab", "arc",
     "plist-lab", "plist", "plist2json", "json2plist",
@@ -16263,6 +16263,19 @@ def parse_args(argv=None):
     parser_json2csharp.add_argument("--namespace", default="MyNamespace", help="Namespace (default: MyNamespace).")
     parser_json2csharp.add_argument("--tui", action="store_true", help="Launch JSON to C# Lab TUI.")
 
+    # --- New 'toml2py-lab' command ---
+    parser_toml2py = subparsers.add_parser(
+        "toml2py-lab",
+        aliases=["toml2py", "t2py"],
+        help="Convert TOML data to Python dataclass or Pydantic format."
+    )
+    parser_toml2py.add_argument("--file", "-f", help="Input TOML file.")
+    parser_toml2py.add_argument("--text", "-t", help="Input TOML text.")
+    parser_toml2py.add_argument("--output", "-o", help="Output file path.")
+    parser_toml2py.add_argument("--framework", choices=["dataclass", "pydantic"], default="dataclass", help="Framework to use.")
+    parser_toml2py.add_argument("--name", default="RootModel", help="Root class name.")
+    parser_toml2py.add_argument("--tui", action="store_true", help="Launch TOML to Py Lab TUI.")
+
     # --- New 'yaml2py-lab' command ---
     parser_yaml2py = subparsers.add_parser(
         "yaml2py-lab",
@@ -24972,6 +24985,14 @@ async def main():
         run_yaml2xml_lab_logic(args)
         return
 
+
+    if args.command in ["toml2py-lab", "toml2py", "t2py"]:
+        if getattr(args, "tui", False):
+            run_tui(args, "tab-toml2py")
+            return
+        from shared.toml2py_lab import run_toml2py_lab_logic
+        run_toml2py_lab_logic(args)
+        return
 
     if args.command in ["yaml2py-lab", "yaml2py", "y2py"]:
         if getattr(args, "tui", False):

--- a/shared/toml2py_lab.py
+++ b/shared/toml2py_lab.py
@@ -1,0 +1,172 @@
+import sys
+import tomlkit
+import argparse
+from typing import Dict, Any, List
+
+class Toml2PyManager:
+    """Manager for converting TOML string to Python dataclass or Pydantic models."""
+
+    def __init__(self):
+        self.class_definitions = []
+        self.class_names = set()
+
+    def generate(self, toml_str: str, framework: str = "dataclass", root_name: str = "RootModel") -> str:
+        self.class_definitions = []
+        self.class_names = set()
+
+        try:
+            data = tomlkit.parse(toml_str)
+            data = data.unwrap()
+        except Exception as e:
+            raise ValueError(f"Invalid TOML: {e}")
+
+        if data is None:
+            return ""
+
+        if not isinstance(data, dict):
+            raise ValueError("TOML root must be an object.")
+
+        self._parse_dict(data, root_name, framework)
+
+        # Note: Child classes are appended first (since we parse children recursively before the parent).
+        # This guarantees dependent types are defined before they are used.
+
+        imports = ""
+        if framework == "dataclass":
+            imports = "from dataclasses import dataclass\nfrom typing import Any, List, Optional\n\n"
+        elif framework == "pydantic":
+            imports = "from pydantic import BaseModel\nfrom typing import Any, List, Optional\n\n"
+
+        return imports + "\n\n".join(self.class_definitions)
+
+    def _parse_dict(self, data: Dict[str, Any], class_name: str, framework: str):
+        # Handle duplicate class names recursively
+        original_class_name = class_name
+        counter = 1
+        while class_name in self.class_names:
+            class_name = f"{original_class_name}{counter}"
+            counter += 1
+
+        self.class_names.add(class_name)
+
+        fields = []
+        for key, value in data.items():
+            py_type = self._infer_type(key, value, framework)
+            # Make sure key is valid python identifier
+            safe_key = self._sanitize_identifier(str(key))
+            fields.append((safe_key, py_type))
+
+        if framework == "dataclass":
+            class_def = f"@dataclass\nclass {class_name}:\n"
+        elif framework == "pydantic":
+            class_def = f"class {class_name}(BaseModel):\n"
+        else:
+            raise ValueError(f"Unknown framework: {framework}")
+
+        if not fields:
+            class_def += "    pass\n"
+        else:
+            for name, type_str in fields:
+                class_def += f"    {name}: Optional[{type_str}] = None\n"
+
+        self.class_definitions.append(class_def.rstrip())
+
+    def _infer_type(self, key: str, value: Any, framework: str) -> str:
+        if value is None:
+            return "Any"
+        elif isinstance(value, bool):
+            return "bool"
+        elif isinstance(value, int):
+            return "int"
+        elif isinstance(value, float):
+            return "float"
+        elif isinstance(value, str):
+            return "str"
+        elif isinstance(value, list):
+            if len(value) == 0:
+                return "List[Any]"
+            else:
+                # Infer type from first element
+                first_elem = value[0]
+                if isinstance(first_elem, dict):
+                    child_class_name = self._to_pascal_case(str(key)) + "Item"
+                    self._parse_dict(first_elem, child_class_name, framework)
+                    return f"List[{child_class_name}]"
+                else:
+                    item_type = self._infer_type(key, first_elem, framework)
+                    return f"List[{item_type}]"
+        elif isinstance(value, dict):
+            child_class_name = self._to_pascal_case(str(key))
+            self._parse_dict(value, child_class_name, framework)
+            return child_class_name
+        else:
+            return "Any"
+
+    def _to_pascal_case(self, s: str) -> str:
+        # replace non-alphanumeric with space
+        s = "".join([c if c.isalnum() else " " for c in s])
+        words = s.split()
+        if not words:
+            return "NestedClass"
+        return "".join(w.capitalize() for w in words)
+
+    def _sanitize_identifier(self, s: str) -> str:
+        if not s:
+            return "field"
+        # replace non-alphanumeric with underscore
+        s = "".join([c if c.isalnum() else "_" for c in s])
+        # cannot start with number
+        if s[0].isdigit():
+            s = "_" + s
+        # python keywords check
+        import keyword
+        if keyword.iskeyword(s):
+            s += "_"
+        return s
+
+def run_toml2py_lab_logic(args) -> bool:
+    """CLI logic for the Toml2Py lab."""
+    import sys
+    manager = Toml2PyManager()
+
+    input_data = ""
+    if getattr(args, 'file', None):
+        try:
+            with open(args.file, 'r') as f:
+                input_data = f.read()
+        except Exception as e:
+            print(f"Error reading file: {e}", file=sys.stderr)
+            return False
+    elif getattr(args, 'text', None):
+        input_data = args.text
+    elif not sys.stdin.isatty():
+        try:
+            input_data = sys.stdin.read()
+        except Exception:
+            pass
+
+    if not input_data:
+        print("Error: No TOML input provided via --file, --text, or stdin.", file=sys.stderr)
+        return False
+
+    framework = getattr(args, 'framework', 'dataclass')
+    root_name = getattr(args, 'name', 'RootModel')
+
+    try:
+        output = manager.generate(input_data, framework=framework, root_name=root_name)
+    except ValueError as e:
+        print(f"Error generating Python code: {e}", file=sys.stderr)
+        return False
+
+    if getattr(args, 'output', None):
+        try:
+            with open(args.output, 'w') as f:
+                f.write(output)
+            print(f"Code saved to {args.output}")
+        except Exception as e:
+            print(f"Error saving to file: {e}", file=sys.stderr)
+            return False
+    else:
+        print(output)
+
+    return True

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -338,6 +338,7 @@ from shared.tui_xml2csv import Xml2CsvTab
 from shared.tui_json2ts import Json2TsLabTab
 from shared.tui_json2go import Json2GoLabTab
 from shared.tui_json2rust import Json2RustLabTab
+from shared.tui_toml2py import Toml2PyLabTab
 from shared.tui_json2dart import Json2DartLabTab
 from shared.tui_json2swift import Json2SwiftLabTab
 from shared.tui_json2csharp import Json2CSharpTab
@@ -4220,6 +4221,7 @@ class AgentTUI(App):
         PaletteCommand("Go to JSON to Dart Lab", "switch_tab_json2dart"),
         PaletteCommand("Go to JSON to Rust Lab", "switch_tab_json2rust"),
         PaletteCommand("Go to JSON to Kotlin Lab", "switch_tab_json2kotlin"),
+        PaletteCommand("Go to TOML to Py Lab", "switch_tab_toml2py"),
         PaletteCommand("Go to JSON to SQL Lab", "switch_tab_json2sql"),
         PaletteCommand("Go to Hash Validator Lab", "switch_tab_hash-validator"),
         PaletteCommand("Go to Hash Lab", "switch_tab_hash"),
@@ -4732,6 +4734,8 @@ class AgentTUI(App):
                 yield Xml2JsonTab()
             with TabPane("JSON to Py", id="tab-json2py"):
                 yield Json2PyLabTab()
+            with TabPane("TOML to Py", id="tab-toml2py"):
+                yield Toml2PyLabTab()
 
             with TabPane("JSON to INI", id="tab-json2ini"):
                 yield Json2IniLabTab()
@@ -5024,6 +5028,9 @@ class AgentTUI(App):
 
     def action_switch_tab_json2py(self) -> None:
         self.query_one(TabbedContent).active = "tab-json2py"
+
+    def action_switch_tab_toml2py(self) -> None:
+        self.query_one(TabbedContent).active = "tab-toml2py"
 
     def action_switch_tab_json2ts(self) -> None:
         self.query_one(TabbedContent).active = "tab-json2ts"

--- a/shared/tui_toml2py.py
+++ b/shared/tui_toml2py.py
@@ -1,0 +1,75 @@
+from textual.app import ComposeResult
+from textual.containers import Vertical, Horizontal
+from textual.widgets import TabPane, Label, Button, TextArea, Select, Input
+from shared.toml2py_lab import Toml2PyManager
+import pyperclip
+
+class Toml2PyLabTab(TabPane):
+    """Tab pane for Toml2Py Lab."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__("TOML to Py", id="tab-toml2py", *args, **kwargs)
+        self.manager = Toml2PyManager()
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="p-4"):
+            yield Label("TOML to Python Dataclass / Pydantic", classes="text-xl text-primary mb-4")
+
+            with Horizontal(classes="mb-4 h-auto"):
+                yield Label("Root Class Name:", classes="w-32")
+                yield Input(value="RootModel", id="input-toml2py-root", classes="w-48 mr-4")
+
+                yield Label("Framework:", classes="w-24")
+                yield Select(
+                    [("Dataclass", "dataclass"), ("Pydantic", "pydantic")],
+                    value="dataclass",
+                    id="select-toml2py-framework",
+                    classes="w-40 mr-4"
+                )
+
+                yield Button("Generate", variant="primary", id="btn-generate-toml2py", classes="mr-4")
+                yield Button("Copy Output", variant="default", id="btn-copy-toml2py")
+
+            with Horizontal():
+                with Vertical(classes="w-1-2 pr-2"):
+                    yield Label("Input (TOML):", classes="mb-2")
+                    yield TextArea(language="toml", id="editor-toml2py-in")
+                with Vertical(classes="w-1-2 pl-2"):
+                    yield Label("Output (Python):", classes="mb-2")
+                    yield TextArea(language="python", read_only=True, id="editor-toml2py-out")
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-generate-toml2py":
+            in_editor = self.query_one("#editor-toml2py-in", TextArea)
+            out_editor = self.query_one("#editor-toml2py-out", TextArea)
+
+            root_name = self.query_one("#input-toml2py-root", Input).value or "RootModel"
+            framework = self.query_one("#select-toml2py-framework", Select).value or "dataclass"
+
+            toml_str = in_editor.text
+            if not toml_str.strip():
+                if hasattr(self.app, 'notify'):
+                    self.app.notify("Input TOML cannot be empty.", severity="warning")
+                return
+
+            try:
+                result = self.manager.generate(toml_str, framework=framework, root_name=root_name)
+                out_editor.text = result
+                if hasattr(self.app, 'notify'):
+                    self.app.notify("Python code generated successfully.")
+            except Exception as e:
+                out_editor.text = f"Error generating code:\n{e}"
+                if hasattr(self.app, 'notify'):
+                    self.app.notify(f"Error: {e}", severity="error")
+
+        elif event.button.id == "btn-copy-toml2py":
+            out_editor = self.query_one("#editor-toml2py-out", TextArea)
+            content = out_editor.text
+            if content:
+                try:
+                    pyperclip.copy(content)
+                    if hasattr(self.app, 'notify'):
+                        self.app.notify("Copied to clipboard!", title="Success")
+                except Exception as e:
+                    if hasattr(self.app, 'notify'):
+                        self.app.notify(f"Failed to copy: {e}", title="Error", severity="error")

--- a/tests/test_toml2py_lab.py
+++ b/tests/test_toml2py_lab.py
@@ -1,0 +1,168 @@
+import pytest
+import io
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+from shared.toml2py_lab import Toml2PyManager, run_toml2py_lab_logic
+
+def test_flat_dataclass():
+    manager = Toml2PyManager()
+    toml_str = 'name = "test"\nage = 30\nis_active = true'
+    result = manager.generate(toml_str, framework="dataclass", root_name="User")
+
+    assert "@dataclass" in result
+    assert "class User:" in result
+    assert "name: Optional[str] = None" in result
+    assert "age: Optional[int] = None" in result
+    assert "is_active: Optional[bool] = None" in result
+
+def test_flat_pydantic():
+    manager = Toml2PyManager()
+    toml_str = "id = 123\nbalance = 99.99"
+    result = manager.generate(toml_str, framework="pydantic", root_name="Account")
+
+    assert "class Account(BaseModel):" in result
+    assert "id: Optional[int] = None" in result
+    assert "balance: Optional[float] = None" in result
+
+def test_nested_objects():
+    manager = Toml2PyManager()
+    toml_str = '[user]\nname = "Alice"\n\n[status]\nstate = "ok"'
+    result = manager.generate(toml_str, framework="dataclass", root_name="Response")
+
+    assert "class User:" in result
+    assert "name: Optional[str] = None" in result
+    assert "class Response:" in result
+    assert "user: Optional[User] = None" in result
+
+    # Check order: nested class should appear before root class
+    assert result.index("class User:") < result.index("class Response:")
+
+def test_lists():
+    manager = Toml2PyManager()
+    toml_str = 'tags = ["a", "b"]\nscores = [1, 2]'
+    result = manager.generate(toml_str)
+
+    assert "tags: Optional[List[str]] = None" in result
+    assert "scores: Optional[List[int]] = None" in result
+
+def test_nested_lists():
+    manager = Toml2PyManager()
+    toml_str = '[[items]]\nid = 1\nname = "item1"\n[[items]]\nid = 2\nname = "item2"'
+    result = manager.generate(toml_str, framework="dataclass", root_name="Cart")
+
+    assert "class ItemsItem:" in result
+    assert "id: Optional[int] = None" in result
+    assert "name: Optional[str] = None" in result
+    assert "class Cart:" in result
+    assert "items: Optional[List[ItemsItem]] = None" in result
+
+def test_invalid_toml():
+    manager = Toml2PyManager()
+    with pytest.raises(ValueError):
+        manager.generate("invalid: toml: :")
+
+def test_sanitize_identifier():
+    manager = Toml2PyManager()
+    toml_str = '"1st_item" = "value"\nclass = "keyword"\n"a-b" = 1'
+    result = manager.generate(toml_str)
+
+    assert "_1st_item: Optional[str] = None" in result
+    assert "class_: Optional[str] = None" in result
+    assert "a_b: Optional[int] = None" in result
+
+@patch('sys.stdout', new_callable=io.StringIO)
+def test_cli_logic_text(mock_stdout):
+    args = argparse.Namespace(
+        text='name = "Charlie"\nage = 40',
+        file=None,
+        output=None,
+        framework="dataclass",
+        name="TestClass",
+        tui=False
+    )
+    result = run_toml2py_lab_logic(args)
+    assert result is True
+
+    output = mock_stdout.getvalue()
+    assert "class TestClass:" in output
+    assert "name: Optional[str] = None" in output
+
+def test_cli_logic_file(tmp_path):
+    toml_file = tmp_path / "input.toml"
+    toml_file.write_text('name = "David"\n', encoding="utf-8")
+
+    py_file = tmp_path / "output.py"
+
+    args = argparse.Namespace(
+        text=None,
+        file=str(toml_file),
+        output=str(py_file),
+        framework="pydantic",
+        name="Person",
+        tui=False
+    )
+
+    with patch('sys.stdout', new_callable=io.StringIO):
+        result = run_toml2py_lab_logic(args)
+        assert result is True
+
+    assert py_file.exists()
+    assert "class Person(BaseModel):" in py_file.read_text()
+    assert "name: Optional[str] = None" in py_file.read_text()
+
+@patch('sys.stderr', new_callable=io.StringIO)
+def test_cli_logic_missing_input(mock_stderr):
+    args = argparse.Namespace(
+        text=None,
+        file=None,
+        output=None,
+        framework="dataclass",
+        name="RootModel",
+        tui=False
+    )
+    with patch('sys.stdin.isatty', return_value=True):
+        result = run_toml2py_lab_logic(args)
+        assert result is False
+
+    assert "No TOML input provided" in mock_stderr.getvalue()
+
+@pytest.mark.asyncio
+async def test_tui_toml2py():
+    """Test the Textual TUI interface."""
+    pytest.importorskip("textual")
+    from textual.app import App, ComposeResult
+    from shared.tui_toml2py import Toml2PyLabTab
+    from textual.widgets import TextArea, Select, Input
+    from textual.widgets import TabbedContent
+
+    class MockApp(App):
+        def compose(self) -> ComposeResult:
+            with TabbedContent():
+                yield Toml2PyLabTab()
+
+    app = MockApp()
+    async with app.run_test(size=(80, 40)) as pilot:
+        await pilot.pause(0.1)
+
+        input_ta = app.query_one("#editor-toml2py-in", TextArea)
+        output_ta = app.query_one("#editor-toml2py-out", TextArea)
+        name_input = app.query_one("#input-toml2py-root", Input)
+        fw_select = app.query_one("#select-toml2py-framework", Select)
+
+        # Test valid conversion
+        toml_data = '[user]\nid = 123\nrole = "admin"'
+        input_ta.load_text(toml_data)
+
+        # Test change input
+        name_input.value = "MyApp"
+
+        from textual.widgets import Button
+        btn = app.query_one("#btn-generate-toml2py", Button)
+        await app.query_one("Toml2PyLabTab").on_button_pressed(Button.Pressed(btn))
+        await pilot.pause(0.1)
+
+        assert "class User:" in output_ta.text
+        assert "class MyApp:" in output_ta.text
+        assert "user: Optional[User] = None" in output_ta.text


### PR DESCRIPTION
Introduces a new `toml2py-lab` feature, which functions similarly to the `yaml2py-lab` and `json2py-lab` features but adds support for converting TOML configuration blocks directly into fully typed Python models (e.g. Dataclasses, Pydantic).

Changes include:
* Manager implementation: `shared/toml2py_lab.py`
* Interactive GUI Tab: `shared/tui_toml2py.py`
* CLI command hookup in `main.py`
* 11 comprehensive unit and integration tests passing correctly in `tests/test_toml2py_lab.py`.

---
*PR created automatically by Jules for task [11393411430744346164](https://jules.google.com/task/11393411430744346164) started by @process-failed-successfully*