### PR TITLE
Add leet speak transformation feature

### DIFF
--- a/shared/text_lab.py
+++ b/shared/text_lab.py
@@ -33,6 +33,8 @@ class TextLabManager:
             return self._to_dot(text)
         elif type == "path":
             return self._to_path(text)
+        elif type == "leet":
+            return self._to_leet(text)
         else:
             raise ValueError(f"Unknown transform type: {type}")
 
@@ -290,6 +292,18 @@ class TextLabManager:
 
     def _to_path(self, text: str) -> str:
         return self._to_snake(text).replace('_', '/')
+
+    def _to_leet(self, text: str) -> str:
+        leet_map = {
+            'A': '4', 'a': '4',
+            'E': '3', 'e': '3',
+            'I': '1', 'i': '1',
+            'L': '1', 'l': '1',
+            'O': '0', 'o': '0',
+            'S': '5', 's': '5',
+            'T': '7', 't': '7'
+        }
+        return ''.join(leet_map.get(c, c) for c in text)
 
     def lorem_ipsum(self, words: int = 100) -> str:
         import random

--- a/tests/test_text_lab.py
+++ b/tests/test_text_lab.py
@@ -248,7 +248,12 @@ class TestTextLab(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.manager.generate_random_string(charset="unknown")
 
-
+    def test_transform_leet(self):
+        # Leet
+        self.assertEqual(self.manager.transform("Leetcode", "leet"), "1337c0d3")
+        self.assertEqual(self.manager.transform("LEETCODE", "leet"), "1337C0D3")
+        self.assertEqual(self.manager.transform("Hello World", "leet"), "H3110 W0r1d")
+        self.assertEqual(self.manager.transform("aeilostAEILOST", "leet"), "43110574311057")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit adds a new 'leet' speak transformation to the text manipulation lab. It performs basic L33tcode character substitutions and provides corresponding unit tests.

---
*PR created automatically by Jules for task [12502296400713462515](https://jules.google.com/task/12502296400713462515) started by @process-failed-successfully*