### PR TITLE
feat: Add SAML Lab for decoding Auth requests

### DIFF
--- a/fix_flake8.sh
+++ b/fix_flake8.sh
@@ -1,3 +1,9 @@
+#!/bin/bash
+sed -i 's/[ \t]*$//' shared/saml_lab.py
+sed -i 's/[ \t]*$//' tests/test_saml_lab.py
+sed -i 's/[ \t]*$//' tests/test_tui_saml.py
+
+cat << 'INNER_EOF' > tests/test_tui_saml.py
 import unittest
 import base64
 from unittest.mock import MagicMock
@@ -51,3 +57,4 @@ class TestSamlLabTab(unittest.IsolatedAsyncioTestCase):
 
 if __name__ == '__main__':
     unittest.main()
+INNER_EOF

--- a/main.py
+++ b/main.py
@@ -384,6 +384,7 @@ KNOWN_COMMANDS = [
     "shell-lab",
     "chemistry-lab", "chem", "periodic",
     "mac-lab", "mac",
+    "saml-lab", "saml",
     "physics-lab", "phys",
     "set-lab", "sets",
     "ip-lab", "ip",
@@ -14677,6 +14678,20 @@ def parse_args(argv=None):
 
     parser_ip_tui = ip_subparsers.add_parser("tui", help="Launch the IP Lab TUI.")
 
+    # --- New 'saml-lab' command ---
+    parser_saml = subparsers.add_parser(
+        "saml-lab", aliases=["saml"],
+        help="SAML utilities (decode AuthnRequest/Response)"
+    )
+    saml_subparsers = parser_saml.add_subparsers(dest="action", help="SAML actions")
+
+    saml_subparsers.add_parser("tui", help="Launch the SAML Lab TUI")
+
+    saml_decode = saml_subparsers.add_parser("decode", help="Decode a SAML string")
+    saml_decode.add_argument("--decode", help="SAML string to decode")
+    saml_decode.add_argument("--file", help="File containing SAML string")
+    saml_decode.add_argument("--inflate", action="store_true", help="Inflate with zlib (used in HTTP-Redirect)")
+
     # --- New 'mac-lab' command ---
     # --- New 'phone-lab' command ---
     parser_phone = subparsers.add_parser(
@@ -25621,6 +25636,17 @@ async def main():
             sys.exit(0)
         else:
             run_mac_lab(args)
+        return
+
+    if args.command in ["saml-lab", "saml"]:
+        if getattr(args, "action", None) == "tui":
+            from shared.tui import AgentTUI
+            app = AgentTUI(project_dir=args.project_dir, start_tab="tab-saml")
+            await app.run_async()
+            sys.exit(0)
+        else:
+            from shared.saml_lab import run_saml_lab_logic
+            run_saml_lab_logic(args)
         return
 
     if args.command in ["ip-lab", "ip"]:

--- a/shared/saml_lab.py
+++ b/shared/saml_lab.py
@@ -1,0 +1,92 @@
+import sys
+import argparse
+import base64
+import zlib
+import urllib.parse
+import xml.dom.minidom
+
+class SamlLabManager:
+    """Manager for SAML operations."""
+
+    def decode(self, saml_string: str, inflate: bool = False) -> str:
+        """
+        Decodes a SAML string.
+        Optionally inflates it (used for HTTP-Redirect binding).
+        Returns pretty-printed XML if valid, else returns the decoded string or throws.
+        """
+        if not saml_string:
+            raise ValueError("Empty SAML string provided.")
+
+        # Sometimes users copy URL-encoded strings
+        if "%" in saml_string:
+            saml_string = urllib.parse.unquote(saml_string)
+
+        # Strip common SAML parameter prefixes if present
+        if saml_string.startswith("SAMLRequest="):
+            saml_string = saml_string[len("SAMLRequest="):]
+        elif saml_string.startswith("SAMLResponse="):
+            saml_string = saml_string[len("SAMLResponse="):]
+
+        # Base64 decode
+        try:
+            # Add padding if missing
+            padding_needed = len(saml_string) % 4
+            if padding_needed:
+                saml_string += "=" * (4 - padding_needed)
+
+            decoded_bytes = base64.b64decode(saml_string, validate=True)
+        except Exception as e:
+            raise ValueError(f"Base64 decoding failed: {e}")
+
+        # Inflate if requested (or auto-detect)
+        # HTTP-Redirect binding uses DEFLATE (without zlib header, usually wbits=-15)
+        if inflate:
+            try:
+                # Try raw deflate first
+                decoded_bytes = zlib.decompress(decoded_bytes, -15)
+            except zlib.error:
+                try:
+                    # Try with zlib header
+                    decoded_bytes = zlib.decompress(decoded_bytes)
+                except Exception as e:
+                    raise ValueError(f"Decompression failed: {e}")
+
+        try:
+            decoded_str = decoded_bytes.decode('utf-8')
+        except UnicodeDecodeError:
+            # Fallback for some weird encodings, but typically it's utf-8
+            decoded_str = decoded_bytes.decode('latin-1', errors='replace')
+
+        # Pretty print if it's XML
+        try:
+            dom = xml.dom.minidom.parseString(decoded_str)
+            return dom.toprettyxml(indent="  ")
+        except Exception:
+            # Not valid XML, just return the decoded string
+            return decoded_str
+
+def run_saml_lab_logic(args: argparse.Namespace):
+    """CLI handler for SAML Lab."""
+    manager = SamlLabManager()
+
+    if getattr(args, 'decode', None) or getattr(args, 'file', None):
+        saml_str = ""
+        if getattr(args, 'decode', None):
+            saml_str = args.decode
+        elif getattr(args, 'file', None):
+            try:
+                with open(args.file, 'r') as f:
+                    saml_str = f.read().strip()
+            except IOError as e:
+                print(f"Error reading file: {e}", file=sys.stderr)
+                sys.exit(1)
+
+        try:
+            result = manager.decode(saml_str, inflate=getattr(args, 'inflate', False))
+            print(result)
+        except Exception as e:
+            print(f"Error decoding SAML: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        print("Error: Must provide --decode or --file.", file=sys.stderr)
+        sys.exit(1)

--- a/shared/saml_lab.py
+++ b/shared/saml_lab.py
@@ -3,7 +3,8 @@ import argparse
 import base64
 import zlib
 import urllib.parse
-import xml.dom.minidom
+import defusedxml.minidom
+
 
 class SamlLabManager:
     """Manager for SAML operations."""
@@ -59,11 +60,12 @@ class SamlLabManager:
 
         # Pretty print if it's XML
         try:
-            dom = xml.dom.minidom.parseString(decoded_str)
+            dom = defusedxml.minidom.parseString(decoded_str)
             return dom.toprettyxml(indent="  ")
         except Exception:
             # Not valid XML, just return the decoded string
             return decoded_str
+
 
 def run_saml_lab_logic(args: argparse.Namespace):
     """CLI handler for SAML Lab."""

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -113,6 +113,7 @@ from shared.tui_net_diag import NetDiagTab
 from shared.tui_cidr import CidrLabTab
 from shared.tui_cheatsheet import CheatsheetTab
 from shared.tui_mac import MacLabTab
+from shared.tui_saml import SamlLabTab
 from shared.tui_size import SizeLabTab
 from shared.tui_typegen import TypegenLabTab
 from shared.tui_hexdump import HexdumpLabTab
@@ -4922,6 +4923,8 @@ class AgentTUI(App):
                 yield TokenLabTab(self.project_dir)
             with TabPane("MAC Lab", id="tab-mac"):
                 yield MacLabTab()
+            with TabPane("SAML Lab", id="tab-saml"):
+                yield SamlLabTab()
             with TabPane("A11y Lab", id="tab-a11y"):
                 yield A11yLabTab(self.project_dir)
             with TabPane("Load Lab", id="tab-load"):

--- a/shared/tui_saml.py
+++ b/shared/tui_saml.py
@@ -1,0 +1,46 @@
+from textual.app import ComposeResult
+from textual.containers import Container, Vertical, Horizontal
+from textual.widgets import Label, Button, Checkbox, TextArea
+from textual import on
+from shared.saml_lab import SamlLabManager
+
+
+class SamlLabTab(Container):
+    """Tab for SAML Lab operations."""
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label("[bold]SAML Lab[/bold]", classes="welcome-text")
+
+            with Vertical(classes="stat-box"):
+                yield Label("Input SAML String (AuthnRequest, Response, etc.):")
+
+                # We use a TextArea so users can paste large multiline SAML chunks easily
+                yield TextArea(id="saml-input", show_line_numbers=True)
+
+                with Horizontal():
+                    yield Checkbox("Deflate (zlib) decompression (Required for HTTP-Redirect binding)", id="saml-inflate-chk", value=True)
+
+                yield Button("Decode & Parse", id="btn-saml-decode", variant="primary")
+
+                yield Label("Decoded Result:")
+                yield TextArea(id="saml-result", show_line_numbers=True, read_only=True)
+
+    @on(Button.Pressed, "#btn-saml-decode")
+    def on_decode(self) -> None:
+        manager = SamlLabManager()
+        saml_str = self.query_one("#saml-input", TextArea).text.strip()
+        inflate = self.query_one("#saml-inflate-chk", Checkbox).value
+        result_area = self.query_one("#saml-result", TextArea)
+
+        if not saml_str:
+            self.notify("Please provide a SAML string.", severity="error")
+            return
+
+        try:
+            result = manager.decode(saml_str, inflate=inflate)
+            result_area.text = result
+            self.notify("SAML Decoded successfully.", severity="information")
+        except Exception as e:
+            result_area.text = f"Error decoding SAML:\n\n{str(e)}"
+            self.notify("SAML Decode failed.", severity="error")

--- a/tests/test_saml_lab.py
+++ b/tests/test_saml_lab.py
@@ -5,6 +5,7 @@ import argparse
 from unittest.mock import patch
 from shared.saml_lab import SamlLabManager, run_saml_lab_logic
 
+
 class TestSamlLabManager(unittest.TestCase):
     def setUp(self):
         self.manager = SamlLabManager()
@@ -48,6 +49,7 @@ class TestSamlLabManager(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.manager.decode("")
 
+
 class TestSamlLabCLI(unittest.TestCase):
     @patch('builtins.print')
     def test_cli_decode(self, mock_print):
@@ -66,6 +68,7 @@ class TestSamlLabCLI(unittest.TestCase):
             if "hello" in call_args[0][0]:
                 called_with_xml = True
         self.assertTrue(called_with_xml)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_saml_lab.py
+++ b/tests/test_saml_lab.py
@@ -1,0 +1,71 @@
+import unittest
+import base64
+import zlib
+import argparse
+from unittest.mock import patch
+from shared.saml_lab import SamlLabManager, run_saml_lab_logic
+
+class TestSamlLabManager(unittest.TestCase):
+    def setUp(self):
+        self.manager = SamlLabManager()
+        self.sample_xml = "<saml:Assertion xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\"><saml:Issuer>test</saml:Issuer></saml:Assertion>"
+
+    def test_decode_plain_base64(self):
+        encoded = base64.b64encode(self.sample_xml.encode('utf-8')).decode('utf-8')
+        result = self.manager.decode(encoded, inflate=False)
+        self.assertIn("saml:Assertion", result)
+        self.assertIn("saml:Issuer", result)
+
+    def test_decode_deflated(self):
+        # Deflate without zlib header
+        compress_obj = zlib.compressobj(zlib.Z_DEFAULT_COMPRESSION, zlib.DEFLATED, -15)
+        compressed = compress_obj.compress(self.sample_xml.encode('utf-8')) + compress_obj.flush()
+
+        encoded = base64.b64encode(compressed).decode('utf-8')
+        result = self.manager.decode(encoded, inflate=True)
+        self.assertIn("saml:Assertion", result)
+
+    def test_decode_deflated_with_header(self):
+        # Deflate with zlib header
+        compressed = zlib.compress(self.sample_xml.encode('utf-8'))
+        encoded = base64.b64encode(compressed).decode('utf-8')
+        result = self.manager.decode(encoded, inflate=True)
+        self.assertIn("saml:Assertion", result)
+
+    def test_decode_url_encoded(self):
+        encoded = base64.b64encode(self.sample_xml.encode('utf-8')).decode('utf-8')
+        # URL encode the base64 string
+        import urllib.parse
+        url_encoded = urllib.parse.quote(encoded)
+        result = self.manager.decode(url_encoded, inflate=False)
+        self.assertIn("saml:Assertion", result)
+
+    def test_decode_invalid_base64(self):
+        with self.assertRaises(ValueError):
+            self.manager.decode("!@#$%^", inflate=False)
+
+    def test_decode_empty(self):
+        with self.assertRaises(ValueError):
+            self.manager.decode("")
+
+class TestSamlLabCLI(unittest.TestCase):
+    @patch('builtins.print')
+    def test_cli_decode(self, mock_print):
+        sample_xml = "<test>hello</test>"
+        encoded = base64.b64encode(sample_xml.encode('utf-8')).decode('utf-8')
+        args = argparse.Namespace(decode=encoded, file=None, inflate=False)
+        try:
+            run_saml_lab_logic(args)
+        except SystemExit:
+            pass
+        mock_print.assert_called()
+        # the output is pretty printed XML, so it might span multiple calls or one large string
+        # Let's check the arguments passed to print
+        called_with_xml = False
+        for call_args in mock_print.call_args_list:
+            if "hello" in call_args[0][0]:
+                called_with_xml = True
+        self.assertTrue(called_with_xml)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_tui_saml.py
+++ b/tests/test_tui_saml.py
@@ -1,0 +1,50 @@
+import unittest
+import base64
+from unittest.mock import MagicMock, patch
+from shared.tui_saml import SamlLabTab
+from textual.app import App
+from textual.widgets import TextArea, Checkbox
+
+class DummyApp(App):
+    def compose(self):
+        yield SamlLabTab()
+
+    async def on_mount(self):
+        self.notify = MagicMock()
+
+class TestSamlLabTab(unittest.IsolatedAsyncioTestCase):
+    async def test_decode_action(self):
+        app = DummyApp()
+        async with app.run_test() as pilot:
+            sample_xml = "<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\"><saml:Issuer xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">TestIssuer</saml:Issuer></samlp:AuthnRequest>"
+            encoded = base64.b64encode(sample_xml.encode('utf-8')).decode('utf-8')
+
+            # Set values
+            app.query_one("#saml-input", TextArea).text = encoded
+            app.query_one("#saml-inflate-chk", Checkbox).value = False
+
+            # Click decode
+            await pilot.click("#btn-saml-decode")
+
+            # Verify result
+            result_text = app.query_one("#saml-result", TextArea).text
+            self.assertIn("TestIssuer", result_text)
+            self.assertIn("samlp:AuthnRequest", result_text)
+
+    async def test_decode_with_saml_request_prefix(self):
+        app = DummyApp()
+        async with app.run_test() as pilot:
+            sample_xml = "<test>data</test>"
+            encoded = base64.b64encode(sample_xml.encode('utf-8')).decode('utf-8')
+
+            app.query_one("#saml-input", TextArea).text = f"SAMLRequest={encoded}"
+            app.query_one("#saml-inflate-chk", Checkbox).value = False
+
+            await pilot.click("#btn-saml-decode")
+
+            result_text = app.query_one("#saml-result", TextArea).text
+            self.assertIn("data", result_text)
+            self.assertIn("<test>", result_text)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Added `shared/saml_lab.py` to handle the SAML decoding and zlib inflation, safely ignoring common parameter prefixes (`SAMLRequest=`, `SAMLResponse=`) before Base64 decoding.
- Added `shared/tui_saml.py` providing a Textual user interface (`TextArea` for input and output, and a toggle for inflation).
- Registered the `saml-lab` command and sub-parsers in `main.py` routing logic.
- Registered the `SamlLabTab` into `shared/tui.py`.
- Wrote tests in `tests/test_saml_lab.py` and `tests/test_tui_saml.py` ensuring proper behavior and coverage.

---
*PR created automatically by Jules for task [13480428987836139901](https://jules.google.com/task/13480428987836139901) started by @process-failed-successfully*