### PR TITLE
feat(cli): add 'parse' action to cron-lab command

### DIFF
--- a/main.py
+++ b/main.py
@@ -21451,6 +21451,20 @@ async def run_cron_lab(args):
             print(f"❌ Cron Error: {result['error']}", file=sys.stderr)
             sys.exit(1)
 
+    elif args.action == "parse":
+        if not args.expression:
+            print("Error: --expression is required for 'parse' action.", file=sys.stderr)
+            sys.exit(1)
+
+        result = manager.parse(args.expression)
+        if result["success"]:
+            import json
+            print(json.dumps(result, indent=2))
+            sys.exit(0)
+        else:
+            print(f"❌ Cron Error: {result['error']}", file=sys.stderr)
+            sys.exit(1)
+
     elif args.action == "next":
         if not args.expression:
             print("Error: --expression is required for 'next' action.", file=sys.stderr)

--- a/tests/test_cron_lab.py
+++ b/tests/test_cron_lab.py
@@ -75,3 +75,24 @@ class TestCronLabCLI(unittest.IsolatedAsyncioTestCase):
         await run_cron_lab(args)
 
         mock_run_tui.assert_called_once_with(args, start_tab="tab-cron")
+
+    @patch("sys.stdout")
+    async def test_run_cron_lab_parse(self, mock_stdout):
+        from main import run_cron_lab
+        import json
+        args = MagicMock()
+        args.action = "parse"
+        args.expression = "* * * * *"
+
+        with self.assertRaises(SystemExit) as cm:
+            await run_cron_lab(args)
+
+        self.assertEqual(cm.exception.code, 0)
+
+        # Check that it attempts to parse and output
+        # It should print json output representing success
+        # The mock stdout will capture print(json.dumps(result, indent=2))
+        args_list = [call_args[0][0] for call_args in mock_stdout.write.call_args_list]
+        output = "".join(args_list)
+        self.assertIn('"success": true', output)
+        self.assertIn('"minute": "*"', output)


### PR DESCRIPTION
Adds missing CLI action mapping and handling for `CronLabManager.parse()`.
This allows users to parse cron expressions into their component parts
via `main.py cron-lab parse --expression "* * * * *"`.

Also adds unit tests for `CronLabManager`.

---
*PR created automatically by Jules for task [9059897303924234150](https://jules.google.com/task/9059897303924234150) started by @process-failed-successfully*