### PR TITLE
feat: Add Makefile generator lab

### DIFF
--- a/main.py
+++ b/main.py
@@ -264,7 +264,7 @@ KNOWN_COMMANDS = [
     "bson-lab", "bson",
     "csv-lab", "csv", "csv2sql-lab", "csv2sql", "c2s", "json2sql-lab", "json2sql", "j2s", "csv2html-lab", "csv2html", "c2h", "json2csv-lab", "j2c", "json2ini-lab", "json2ini", "j2i", "csv2json-lab", "c2j", "csv2yaml-lab", "csv2yaml", "c2y", "env2json-lab", "env2json", "json2env", "json2md-lab", "json2md", "csv2md-lab", "csv2md", "md2csv-lab", "md2csv", "m2c", "csv2toml-lab", "csv2toml", "c2t", "yaml2csv-lab", "yaml2csv", "y2c", "xml2csv-lab", "xml2csv", "x2c", "toml2csv-lab", "toml2csv", "t2c", "yaml2json-lab", "yaml2json", "y2j", "json2py-lab", "json2py", "j2py", "toml2py-lab", "toml2py", "t2py", "json2yaml-lab", "json2yaml", "j2y", "yaml2toml-lab", "yaml2toml", "toml2yaml", "y2t", "xml2toml-lab", "xml2toml", "toml2xml", "x2t", "json2toml-lab", "json2toml", "j2t", "xml2yaml-lab", "xml2yaml", "x2y", "yaml2xml-lab", "yaml2xml", "y2x", "yaml2py-lab", "yaml2py", "y2py", "json2ts-lab", "json2ts", "j2ts", "json2go-lab", "json2go", "j2go", "json2dart-lab", "json2dart", "j2dart", "json2swift-lab", "json2swift", "j2swift", "json2csharp-lab", "json2csharp", "j2cs", "json2rust-lab", "json2rust", "j2rs", "excel-lab", "xls", "xlsx", "excel", "template-lab", "tpl", "image-lab", "img", "exif-lab", "exif", "ocr-lab", "ocr", "media-lab", "media", "xml-lab", "xml", "lorem-lab", "lorem", "lipsum", "bip39-lab", "bip39", "magic-decode-lab", "magic-decode", "mdecode", "endian-lab", "endian", "entropy-lab", "entropy",
     "ical-lab", "ical", "ics",
-    "markdown-lab", "md", "md-lab", "yaml-lab", "yaml", "ini-lab", "ini", "toml-lab", "toml", "net-lab", "net", "archive-lab", "arc",
+    "markdown-lab", "md", "md-lab", "yaml-lab", "yaml", "ini-lab", "ini", "toml-lab", "toml", "net-lab", "net", "archive-lab", "arc", "makefile-lab", "makefile",
     "plist-lab", "plist", "plist2json", "json2plist",
     "props-lab", "props", "properties",
     "run2compose-lab", "run2compose", "r2c",
@@ -16772,6 +16772,15 @@ def parse_args(argv=None):
     parser_yaml_validate = yaml_subparsers.add_parser("validate", help="Validate YAML.")
     parser_yaml_validate.add_argument("input", help="YAML string or file path.")
 
+    # --- New 'makefile-lab' command ---
+    parser_makefile_lab = subparsers.add_parser(
+        "makefile-lab",
+        aliases=["makefile"],
+        help="Generate standard Makefiles based on language profiles."
+    )
+    parser_makefile_lab.add_argument("--lang", type=str, required=True, help="The programming language profile (e.g., python, node, go, rust, generic)")
+    parser_makefile_lab.add_argument("--output", type=str, help="Output file path (default: stdout)")
+
     # --- New 'toml-lab' command ---
     parser_toml = subparsers.add_parser(
         "toml-lab",
@@ -25606,6 +25615,11 @@ async def main():
 
     if args.command in ["stats-lab", "stats", "codestats"]:
         run_stats_lab(args)
+        return
+
+    if args.command in ["makefile-lab", "makefile"]:
+        from shared.makefile_lab import run_makefile_lab_logic
+        run_makefile_lab_logic(args)
         return
 
     if args.command in ["disk-usage", "du", "usage"]:

--- a/shared/makefile_lab.py
+++ b/shared/makefile_lab.py
@@ -1,0 +1,97 @@
+import sys
+from typing import Dict, Any
+
+class MakefileLabManager:
+    """Generates standard Makefiles based on language profiles."""
+
+    PROFILES = {
+        "python": {
+            "build": "",
+            "install": "pip install -r requirements.txt",
+            "test": "pytest",
+            "lint": "flake8 .",
+            "clean": "find . -type d -name __pycache__ -exec rm -r {} +",
+            "run": "python main.py"
+        },
+        "node": {
+            "build": "npm run build",
+            "install": "npm install",
+            "test": "npm test",
+            "lint": "npm run lint",
+            "clean": "rm -rf node_modules dist",
+            "run": "npm start"
+        },
+        "go": {
+            "build": "go build -o bin/app",
+            "install": "go mod download",
+            "test": "go test ./...",
+            "lint": "golangci-lint run",
+            "clean": "rm -rf bin/",
+            "run": "go run ."
+        },
+        "rust": {
+            "build": "cargo build --release",
+            "install": "",
+            "test": "cargo test",
+            "lint": "cargo clippy",
+            "clean": "cargo clean",
+            "run": "cargo run"
+        },
+        "generic": {
+            "build": "echo 'Build step'",
+            "install": "echo 'Install dependencies step'",
+            "test": "echo 'Test step'",
+            "lint": "echo 'Lint step'",
+            "clean": "echo 'Clean step'",
+            "run": "echo 'Run step'"
+        }
+    }
+
+    def generate(self, lang: str) -> str:
+        lang = lang.lower()
+        if lang not in self.PROFILES:
+            raise ValueError(f"Unknown language profile: {lang}. Available: {', '.join(self.PROFILES.keys())}")
+
+        profile = self.PROFILES[lang]
+
+        lines = []
+        lines.append(f"# Makefile for {lang.capitalize()} Project")
+        lines.append(".PHONY: all build install test lint clean run")
+        lines.append("")
+        lines.append("all: clean install lint test build")
+        lines.append("")
+
+        # We ensure commands with empty strings aren't completely blank targets, but simple echo or empty
+        for target, cmd in profile.items():
+            lines.append(f"{target}:")
+            if cmd:
+                lines.append(f"\t{cmd}")
+            else:
+                lines.append("\t@echo 'Nothing to do for this target'")
+            lines.append("")
+
+        return "\n".join(lines)
+
+
+def run_makefile_lab_logic(args):
+    """CLI logic for Makefile Lab."""
+    manager = MakefileLabManager()
+
+    try:
+        content = manager.generate(args.lang)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if getattr(args, "output", None):
+        try:
+            with open(args.output, "w") as f:
+                f.write(content)
+            print(f"Makefile generated and saved to {args.output}")
+        except OSError as e:
+            print(f"Error writing to file: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        print(content)
+
+    sys.exit(0)

--- a/tests/test_makefile_lab.py
+++ b/tests/test_makefile_lab.py
@@ -1,0 +1,43 @@
+import unittest
+import os
+import tempfile
+from pathlib import Path
+from shared.makefile_lab import MakefileLabManager
+
+class TestMakefileLabManager(unittest.TestCase):
+    def setUp(self):
+        self.manager = MakefileLabManager()
+
+    def test_generate_python(self):
+        content = self.manager.generate("python")
+        self.assertIn("Makefile for Python Project", content)
+        self.assertIn("all: clean install lint test build", content)
+        self.assertIn("pytest", content)
+        self.assertIn("flake8", content)
+        self.assertIn("find . -type d -name __pycache__", content)
+
+    def test_generate_node(self):
+        content = self.manager.generate("Node")
+        self.assertIn("Makefile for Node Project", content)
+        self.assertIn("npm run build", content)
+        self.assertIn("npm test", content)
+
+    def test_generate_go(self):
+        content = self.manager.generate("GO")
+        self.assertIn("Makefile for Go Project", content)
+        self.assertIn("go build", content)
+        self.assertIn("golangci-lint", content)
+
+    def test_generate_rust(self):
+        content = self.manager.generate("rust")
+        self.assertIn("Makefile for Rust Project", content)
+        self.assertIn("cargo build", content)
+        self.assertIn("cargo test", content)
+        self.assertIn("@echo 'Nothing to do for this target'", content) # Install is empty for rust
+
+    def test_invalid_language(self):
+        with self.assertRaises(ValueError):
+            self.manager.generate("invalid_lang")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR introduces `makefile-lab`, a simple but highly useful CLI tool that generates standard Makefiles with typical targets (`build`, `test`, `lint`, `clean`, `run`) based on a target programming language profile.

- Added `shared/makefile_lab.py` containing the logic and profiles.
- Integrated into `main.py` under the `makefile-lab` and `makefile` aliases.
- Added corresponding unit tests in `tests/test_makefile_lab.py`.
- Ensured it does not conflict with existing parsers or test logic like `test_did_you_mean.py`.

---
*PR created automatically by Jules for task [13393775854069248082](https://jules.google.com/task/13393775854069248082) started by @process-failed-successfully*