### PR TITLE
feat: add PowerShell target to cURL Converter Lab

### DIFF
--- a/shared/curl_lab.py
+++ b/shared/curl_lab.py
@@ -241,6 +241,50 @@ class CurlLabManager:
 
         return "\n".join(lines)
 
+    def to_powershell_iwr(self, parsed: Dict[str, Any]) -> str:
+        """
+        Converts parsed cURL data into PowerShell Invoke-WebRequest code.
+        """
+        lines = []
+        method = parsed['method']
+        url = parsed['url']
+
+        cmd_parts = ["Invoke-WebRequest", f"-Uri '{url}'", f"-Method {method}"]
+
+        if parsed['headers']:
+            lines.append("$headers = @{")
+            for k, v in parsed['headers'].items():
+                lines.append(f"  '{k}' = '{v}'")
+            lines.append("}")
+            cmd_parts.append("-Headers $headers")
+
+        if parsed['auth']:
+            user, pwd = parsed['auth']
+            # Creating credentials in PS
+            lines.append(f"$user = '{user}'")
+            lines.append(f"$pass = '{pwd}' | ConvertTo-SecureString -AsPlainText -Force")
+            lines.append("$cred = New-Object System.Management.Automation.PSCredential ($user, $pass)")
+            cmd_parts.append("-Credential $cred")
+
+        if parsed['data'] is not None:
+            # Check if json
+            is_json = parsed['headers'].get('Content-Type', '').lower() == 'application/json'
+            if is_json:
+                try:
+                    json_data = json.loads(parsed['data'])
+                    # Let powershell format it
+                    lines.append(f"$body = @'")
+                    lines.append(json.dumps(json_data, indent=2))
+                    lines.append("'@")
+                except json.JSONDecodeError:
+                    lines.append(f"$body = '{parsed['data']}'")
+            else:
+                lines.append(f"$body = '{parsed['data']}'")
+            cmd_parts.append("-Body $body")
+
+        lines.append(" ".join(cmd_parts))
+        return "\n".join(lines)
+
     def to_json(self, parsed: Dict[str, Any]) -> str:
         """
         Converts parsed cURL data into a formatted JSON string.
@@ -285,10 +329,12 @@ def run_curl_lab_logic(args):
             print(manager.to_js_fetch(parsed))
         elif target == 'go':
             print(manager.to_go_http(parsed))
+        elif target == 'powershell':
+            print(manager.to_powershell_iwr(parsed))
         elif target == 'json':
             print(manager.to_json(parsed))
         else:
-            print(f"Error: Unknown target language '{target}'. Valid options: python, js, go, json.", file=sys.stderr)
+            print(f"Error: Unknown target language '{target}'. Valid options: python, js, go, powershell, json.", file=sys.stderr)
             sys.exit(1)
 
     except Exception as e:

--- a/shared/tui_curl.py
+++ b/shared/tui_curl.py
@@ -36,6 +36,8 @@ class CurlLabTab(ScrollableContainer):
                             yield TextArea(id="curl-output-js", language="javascript", read_only=True)
                         with TabPane("Go (net/http)"):
                             yield TextArea(id="curl-output-go", language="go", read_only=True)
+                        with TabPane("PowerShell (Invoke-WebRequest)"):
+                            yield TextArea(id="curl-output-ps", disabled=True)
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "btn-curl-convert":
@@ -57,10 +59,12 @@ class CurlLabTab(ScrollableContainer):
             py_code = self.manager.to_python_requests(parsed)
             js_code = self.manager.to_js_fetch(parsed)
             go_code = self.manager.to_go_http(parsed)
+            ps_code = self.manager.to_powershell_iwr(parsed)
 
             self.query_one("#curl-output-python", TextArea).text = py_code
             self.query_one("#curl-output-js", TextArea).text = js_code
             self.query_one("#curl-output-go", TextArea).text = go_code
+            self.query_one("#curl-output-ps", TextArea).text = ps_code
 
             self.app.notify("cURL command successfully converted.")
         except Exception as e:
@@ -71,4 +75,5 @@ class CurlLabTab(ScrollableContainer):
         self.query_one("#curl-output-python", TextArea).text = ""
         self.query_one("#curl-output-js", TextArea).text = ""
         self.query_one("#curl-output-go", TextArea).text = ""
+        self.query_one("#curl-output-ps", TextArea).text = ""
         self.app.notify("Fields cleared.")

--- a/tests/test_curl_lab.py
+++ b/tests/test_curl_lab.py
@@ -138,6 +138,24 @@ class TestCurlLabManager(unittest.TestCase):
         self.assertIn('"data": "{\\"key\\": \\"value\\"}"', json_output)
         self.assertIn('"auth": [\n    "user",\n    "pass"\n  ]', json_output)
 
+    def test_to_powershell_iwr(self):
+        parsed = {
+            'url': 'https://api.example.com',
+            'method': 'POST',
+            'headers': {'Content-Type': 'application/json'},
+            'data': '{"key": "value"}',
+            'auth': ['user', 'pass']
+        }
+
+        code = self.manager.to_powershell_iwr(parsed)
+        self.assertIn("Invoke-WebRequest -Uri 'https://api.example.com' -Method POST", code)
+        self.assertIn("$headers = @{", code)
+        self.assertIn("'Content-Type' = 'application/json'", code)
+        self.assertIn("$user = 'user'", code)
+        self.assertIn("$pass = 'pass' | ConvertTo-SecureString", code)
+        self.assertIn("$body = @'", code)
+        self.assertIn('"key": "value"', code)
+
     def test_parse_curl_argparse_error(self):
         # argparse error like an unknown flag will be ignored by parse_known_args
         # But if the user provides an invalid option like --help or -h it would exit.
@@ -185,5 +203,20 @@ class TestCurlLabCli(unittest.TestCase):
 
         self.assertIn('"url": "https://api.example.com"', output)
         self.assertIn('"method": "GET"', output)
+
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_cli_powershell(self, mock_stdout):
+        args = MagicMock()
+        args.tui = False
+        args.command_str = "curl https://api.example.com"
+        args.target = "powershell"
+
+        run_curl_lab_logic(args)
+        output = mock_stdout.getvalue()
+
+        self.assertIn("Invoke-WebRequest", output)
+        self.assertIn("-Uri 'https://api.example.com'", output)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added support for converting cURL commands to PowerShell `Invoke-WebRequest` code. This includes a new translation method in `shared.curl_lab.CurlLabManager`, handling the target 'powershell' in the CLI router, and adding a new `TextArea` widget to the Textual TUI via `shared/tui_curl.py`. Also added strong tests covering the new functionality.

---
*PR created automatically by Jules for task [16885415031758914490](https://jules.google.com/task/16885415031758914490) started by @process-failed-successfully*