### PR TITLE
feat(ip-lab): add subnet calculation logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -14717,6 +14717,9 @@ def parse_args(argv=None):
     parser_ip_info = ip_subparsers.add_parser("info", help="Get information about an IP address.")
     parser_ip_info.add_argument("ip", help="The IP address to inspect.")
 
+    parser_ip_subnet = ip_subparsers.add_parser("subnet", help="Get information about a CIDR subnet block.")
+    parser_ip_subnet.add_argument("cidr", help="The CIDR block to inspect (e.g. 192.168.1.0/24).")
+
     parser_ip_tui = ip_subparsers.add_parser("tui", help="Launch the IP Lab TUI.")
 
     # --- New 'saml-lab' command ---

--- a/shared/ip_lab.py
+++ b/shared/ip_lab.py
@@ -60,6 +60,40 @@ class IPLabManager:
         except ValueError:
             return None
 
+    @staticmethod
+    def get_subnet_info(cidr_str):
+        """Returns subnet information for a given CIDR block."""
+        import ipaddress
+        try:
+            net = ipaddress.ip_network(cidr_str, strict=False)
+            info = {
+                'network_address': str(net.network_address),
+                'netmask': str(net.netmask),
+                'hostmask': str(net.hostmask),
+                'prefixlen': net.prefixlen,
+                'num_addresses': net.num_addresses,
+                'version': net.version,
+            }
+            if net.version == 4:
+                info['broadcast_address'] = str(net.broadcast_address)
+                # For IPv4, usable hosts are num_addresses - 2 (network and broadcast), unless /32 or /31
+                if net.prefixlen >= 31:
+                    info['usable_hosts'] = net.num_addresses
+                    info['host_range'] = f"{net.network_address} - {net.broadcast_address}"
+                else:
+                    info['usable_hosts'] = net.num_addresses - 2
+                    info['host_range'] = f"{net.network_address + 1} - {net.broadcast_address - 1}"
+            elif net.version == 6:
+                # IPv6 has no broadcast address, anycast could be considered but generally host count is just num_addresses
+                info['usable_hosts'] = net.num_addresses
+                if net.num_addresses > 1:
+                    info['host_range'] = f"{net[0]} - {net[-1]}"
+                else:
+                    info['host_range'] = f"{net[0]} - {net[0]}"
+            return info
+        except ValueError:
+            return None
+
 
 def run_ip_lab_logic(args):
     """CLI logic for ip-lab."""
@@ -121,6 +155,28 @@ def run_ip_lab_logic(args):
                 print(f"Hex: {info['hex']}")
         else:
             print(f"Invalid IP address: {args.ip}")
+            return False
+
+    elif args.action == 'subnet':
+        if not args.cidr:
+            print("CIDR string required for subnet action.")
+            return False
+
+        info = manager.get_subnet_info(args.cidr)
+        if info:
+            print(f"CIDR: {args.cidr}")
+            print(f"Version: IPv{info['version']}")
+            print(f"Network Address: {info['network_address']}")
+            print(f"Netmask: {info['netmask']}")
+            print(f"Hostmask: {info['hostmask']}")
+            if 'broadcast_address' in info:
+                print(f"Broadcast Address: {info['broadcast_address']}")
+            print(f"Total Addresses: {info['num_addresses']}")
+            print(f"Usable Hosts: {info['usable_hosts']}")
+            if 'host_range' in info:
+                print(f"Host Range: {info['host_range']}")
+        else:
+            print(f"Invalid CIDR format: {args.cidr}")
             return False
 
     return True

--- a/tests/test_ip_lab.py
+++ b/tests/test_ip_lab.py
@@ -59,6 +59,37 @@ class TestIPLabManager(unittest.TestCase):
         info = self.manager.get_info('invalid')
         self.assertIsNone(info)
 
+    def test_get_subnet_info_ipv4(self):
+        info = self.manager.get_subnet_info('192.168.1.0/24')
+        self.assertEqual(info['version'], 4)
+        self.assertEqual(info['network_address'], '192.168.1.0')
+        self.assertEqual(info['netmask'], '255.255.255.0')
+        self.assertEqual(info['hostmask'], '0.0.0.255')
+        self.assertEqual(info['broadcast_address'], '192.168.1.255')
+        self.assertEqual(info['num_addresses'], 256)
+        self.assertEqual(info['usable_hosts'], 254)
+        self.assertEqual(info['host_range'], '192.168.1.1 - 192.168.1.254')
+
+    def test_get_subnet_info_ipv4_32(self):
+        info = self.manager.get_subnet_info('10.0.0.1/32')
+        self.assertEqual(info['version'], 4)
+        self.assertEqual(info['num_addresses'], 1)
+        self.assertEqual(info['usable_hosts'], 1)
+        self.assertEqual(info['host_range'], '10.0.0.1 - 10.0.0.1')
+
+    def test_get_subnet_info_ipv6(self):
+        info = self.manager.get_subnet_info('2001:db8::/32')
+        self.assertEqual(info['version'], 6)
+        self.assertEqual(info['network_address'], '2001:db8::')
+        self.assertEqual(info['netmask'], 'ffff:ffff::')
+        self.assertEqual(info['num_addresses'], 2**(128-32))
+        self.assertEqual(info['usable_hosts'], 2**(128-32))
+        self.assertTrue('2001:db8:: - 2001:db8:ffff:ffff:ffff:ffff:ffff:ffff' in info['host_range'])
+
+    def test_get_subnet_info_invalid(self):
+        info = self.manager.get_subnet_info('invalid')
+        self.assertIsNone(info)
+
 
 class TestIPLabCLI(unittest.TestCase):
     @patch('shared.ip_lab.IPLabManager.get_public_ip')
@@ -96,6 +127,26 @@ class TestIPLabCLI(unittest.TestCase):
             self.assertTrue(result)
             mock_print.assert_any_call("Geolocating 1.2.3.4...")
             mock_print.assert_any_call("City: Test City")
+
+    @patch('shared.ip_lab.IPLabManager.get_subnet_info')
+    def test_run_subnet(self, mock_get_subnet_info):
+        mock_get_subnet_info.return_value = {
+            'version': 4,
+            'network_address': '192.168.1.0',
+            'netmask': '255.255.255.0',
+            'hostmask': '0.0.0.255',
+            'broadcast_address': '192.168.1.255',
+            'num_addresses': 256,
+            'usable_hosts': 254,
+            'host_range': '192.168.1.1 - 192.168.1.254'
+        }
+        args = argparse.Namespace(action='subnet', cidr='192.168.1.0/24')
+
+        with patch('builtins.print') as mock_print:
+            result = run_ip_lab_logic(args)
+            self.assertTrue(result)
+            mock_print.assert_any_call("CIDR: 192.168.1.0/24")
+            mock_print.assert_any_call("Network Address: 192.168.1.0")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR introduces a new `subnet` subcommand to the `ip-lab` tool.
It allows users to quickly inspect CIDR blocks and calculate network details, making the tool much more useful for networking tasks.
It provides comprehensive unit and CLI testing for all functionality.

---
*PR created automatically by Jules for task [10365540517446120570](https://jules.google.com/task/10365540517446120570) started by @process-failed-successfully*