### PR TITLE
feat: add Rust (reqwest) code generation to curl-lab

### DIFF
--- a/main.py
+++ b/main.py
@@ -17680,11 +17680,11 @@ def parse_args(argv=None):
     parser_curl = subparsers.add_parser(
         "curl-lab",
         aliases=["curl"],
-        help="Convert cURL commands to Python, JS, and Go code."
+        help="Convert cURL commands to Python, JS, Go, and Rust code."
     )
     parser_curl.add_argument("--tui", action="store_true", help="Launch the TUI interface.")
     parser_curl.add_argument("command_str", nargs="?", help="The cURL command string to convert.")
-    parser_curl.add_argument("--target", choices=["python", "js", "go", "json"], default="python", help="Target language for CLI conversion (default: python).")
+    parser_curl.add_argument("--target", choices=["python", "js", "go", "rust", "powershell", "json"], default="python", help="Target language for CLI conversion (default: python).")
 
     # --- New 'vcard-lab' command ---
     parser_vcard = subparsers.add_parser(

--- a/shared/curl_lab.py
+++ b/shared/curl_lab.py
@@ -241,6 +241,63 @@ class CurlLabManager:
 
         return "\n".join(lines)
 
+    def to_rust_reqwest(self, parsed: Dict[str, Any]) -> str:
+        """
+        Converts parsed cURL data into Rust reqwest code.
+        """
+        lines = [
+            "use reqwest::Client;",
+            "use std::error::Error;",
+            "",
+            "#[tokio::main]",
+            "async fn main() -> Result<(), Box<dyn Error>> {",
+            "    let client = Client::new();",
+        ]
+
+        if parsed['headers']:
+            lines.append("    let mut headers = reqwest::header::HeaderMap::new();")
+            for k, v in parsed['headers'].items():
+                lines.append(f"    headers.insert({json.dumps(k)}, {json.dumps(v)}.parse()?);")
+
+        req_method = parsed['method'].lower()
+        # rust reqwest method syntax e.g. client.get, client.post
+        lines.append(f"    let mut request = client.{req_method}({json.dumps(parsed['url'])});")
+
+        if parsed['headers']:
+            lines.append("    request = request.headers(headers);")
+
+        if parsed['auth']:
+            user, pwd = parsed['auth']
+            # basic_auth(username, Some(password))
+            lines.append(f"    request = request.basic_auth({json.dumps(user)}, Some({json.dumps(pwd)}));")
+
+        if parsed['data'] is not None:
+            # Check if json
+            is_json = parsed['headers'].get('Content-Type', '').lower() == 'application/json'
+            if is_json:
+                try:
+                    # formatting json object string in Rust isn't strictly necessary but helpful to pass a raw string
+                    # or serde_json macro
+                    json_data = json.loads(parsed['data'])
+                    json_str = json.dumps(json_data, indent=4)
+                    # use raw string literal for json
+                    lines.append(f"    let body = r#\"{json_str}\"#;")
+                    # We can use .body or since we know it's json, reqwest has .body() taking anything impl Into<Body>
+                    lines.append("    request = request.body(body.to_owned());")
+                except json.JSONDecodeError:
+                    lines.append(f"    request = request.body(r#\"{parsed['data']}\"#.to_owned());")
+            else:
+                lines.append(f"    request = request.body(r#\"{parsed['data']}\"#.to_owned());")
+
+        lines.append("")
+        lines.append("    let response = request.send().await?;")
+        lines.append("    println!(\"Status: {}\", response.status());")
+        lines.append("    println!(\"Body:\\n{}\", response.text().await?);")
+        lines.append("")
+        lines.append("    Ok(())")
+        lines.append("}")
+        return "\n".join(lines)
+
     def to_powershell_iwr(self, parsed: Dict[str, Any]) -> str:
         """
         Converts parsed cURL data into PowerShell Invoke-WebRequest code.
@@ -331,10 +388,12 @@ def run_curl_lab_logic(args):
             print(manager.to_go_http(parsed))
         elif target == 'powershell':
             print(manager.to_powershell_iwr(parsed))
+        elif target == 'rust':
+            print(manager.to_rust_reqwest(parsed))
         elif target == 'json':
             print(manager.to_json(parsed))
         else:
-            print(f"Error: Unknown target language '{target}'. Valid options: python, js, go, powershell, json.", file=sys.stderr)
+            print(f"Error: Unknown target language '{target}'. Valid options: python, js, go, powershell, rust, json.", file=sys.stderr)
             sys.exit(1)
 
     except Exception as e:

--- a/shared/tui_curl.py
+++ b/shared/tui_curl.py
@@ -38,6 +38,8 @@ class CurlLabTab(ScrollableContainer):
                             yield TextArea(id="curl-output-go", language="go", read_only=True)
                         with TabPane("PowerShell (Invoke-WebRequest)"):
                             yield TextArea(id="curl-output-ps", disabled=True)
+                        with TabPane("Rust (reqwest)"):
+                            yield TextArea(id="curl-output-rust", read_only=True)
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "btn-curl-convert":
@@ -60,11 +62,13 @@ class CurlLabTab(ScrollableContainer):
             js_code = self.manager.to_js_fetch(parsed)
             go_code = self.manager.to_go_http(parsed)
             ps_code = self.manager.to_powershell_iwr(parsed)
+            rust_code = self.manager.to_rust_reqwest(parsed)
 
             self.query_one("#curl-output-python", TextArea).text = py_code
             self.query_one("#curl-output-js", TextArea).text = js_code
             self.query_one("#curl-output-go", TextArea).text = go_code
             self.query_one("#curl-output-ps", TextArea).text = ps_code
+            self.query_one("#curl-output-rust", TextArea).text = rust_code
 
             self.app.notify("cURL command successfully converted.")
         except Exception as e:
@@ -76,4 +80,5 @@ class CurlLabTab(ScrollableContainer):
         self.query_one("#curl-output-js", TextArea).text = ""
         self.query_one("#curl-output-go", TextArea).text = ""
         self.query_one("#curl-output-ps", TextArea).text = ""
+        self.query_one("#curl-output-rust", TextArea).text = ""
         self.app.notify("Fields cleared.")

--- a/tests/test_curl_lab.py
+++ b/tests/test_curl_lab.py
@@ -138,6 +138,23 @@ class TestCurlLabManager(unittest.TestCase):
         self.assertIn('"data": "{\\"key\\": \\"value\\"}"', json_output)
         self.assertIn('"auth": [\n    "user",\n    "pass"\n  ]', json_output)
 
+    def test_to_rust_reqwest(self):
+        parsed = {
+            'url': 'https://api.example.com',
+            'method': 'POST',
+            'headers': {'Content-Type': 'application/json'},
+            'data': '{"key": "value"}',
+            'auth': ['user', 'pass']
+        }
+
+        code = self.manager.to_rust_reqwest(parsed)
+        self.assertIn("use reqwest::Client;", code)
+        self.assertIn("let mut request = client.post(\"https://api.example.com\");", code)
+        self.assertIn("request = request.basic_auth(\"user\", Some(\"pass\"));", code)
+        self.assertIn("let body = r#\"{", code)
+        self.assertIn('"key": "value"', code)
+        self.assertIn("request = request.body(body.to_owned());", code)
+
     def test_to_powershell_iwr(self):
         parsed = {
             'url': 'https://api.example.com',


### PR DESCRIPTION
Adds a new functionality to the cURL Lab tool allowing for generation of Rust code leveraging the `reqwest` and `tokio` crates.

---
*PR created automatically by Jules for task [15628727100126812004](https://jules.google.com/task/15628727100126812004) started by @process-failed-successfully*