### PR TITLE
feat: add tree-lab command to generate ASCII directory trees

### DIFF
--- a/main.py
+++ b/main.py
@@ -384,7 +384,7 @@ KNOWN_COMMANDS = [
     "subtitle-lab", "sub",
     "shell-lab",
     "chemistry-lab", "chem", "periodic",
-    "mac-lab", "mac",
+    "mac-lab", "mac", "tree-lab",
     "saml-lab", "saml",
     "physics-lab", "phys",
     "set-lab", "sets",
@@ -14784,6 +14784,15 @@ def parse_args(argv=None):
     saml_decode.add_argument("--inflate", action="store_true", help="Inflate with zlib (used in HTTP-Redirect)")
 
     # --- New 'mac-lab' command ---
+    # --- New 'tree-lab' command ---
+    parser_tree_lab = subparsers.add_parser(
+        "tree-lab",
+        help="Generate ASCII directory trees."
+    )
+    parser_tree_lab.add_argument("dir", nargs="?", default=".", help="Directory to generate tree for (default: .)")
+    parser_tree_lab.add_argument("--max-depth", type=int, default=-1, help="Maximum depth to traverse (-1 for infinite).")
+    parser_tree_lab.add_argument("--exclude", nargs="*", help="Directories or files to exclude.")
+
     # --- New 'phone-lab' command ---
     parser_phone = subparsers.add_parser(
         "phone-lab",
@@ -25308,6 +25317,11 @@ async def main():
     if args.command in ["md2csv-lab", "md2csv", "m2c"]:
         from shared.md2csv_lab import run_md2csv_lab_logic
         run_md2csv_lab_logic(args)
+        return
+
+    if args.command == "tree-lab":
+        from shared.tree_lab import run_tree_lab_logic
+        run_tree_lab_logic(args)
         return
 
     if args.command in ["csv2toml-lab", "csv2toml", "c2t"]:

--- a/shared/tree_lab.py
+++ b/shared/tree_lab.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from typing import List, Optional
+
+
+class TreeLabManager:
+    def __init__(self, exclude: Optional[List[str]] = None):
+        if exclude is None:
+            self.exclude = [".git", "__pycache__", "node_modules", ".venv", "venv"]
+        else:
+            self.exclude = exclude
+
+    def generate_tree(self, dir_path: Path, max_depth: int = -1, prefix: str = "", current_depth: int = 0) -> str:
+        """
+        Generates an ASCII tree representation of the given directory.
+        """
+        if not dir_path.is_dir():
+            return f"Error: {dir_path} is not a directory."
+
+        # Sort files and directories, directories first
+        try:
+            entries = sorted(dir_path.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower()))
+        except PermissionError:
+            return prefix + "[Permission Denied]\n"
+
+        entries = [e for e in entries if e.name not in self.exclude]
+
+        tree_str = ""
+        for i, entry in enumerate(entries):
+            is_last = (i == len(entries) - 1)
+            connector = "└── " if is_last else "├── "
+            tree_str += f"{prefix}{connector}{entry.name}\n"
+
+            if entry.is_dir():
+                if max_depth == -1 or current_depth < max_depth:
+                    extension = "    " if is_last else "│   "
+                    tree_str += self.generate_tree(entry, max_depth, prefix + extension, current_depth + 1)
+
+        return tree_str
+
+
+def run_tree_lab_logic(args):
+    """CLI logic for the tree-lab command."""
+    manager = TreeLabManager(exclude=args.exclude)
+
+    target_dir = Path(args.dir)
+    if not target_dir.exists():
+        print(f"Error: Directory '{target_dir}' does not exist.")
+        return
+
+    print(f"{target_dir.resolve().name}/")
+    print(manager.generate_tree(target_dir, max_depth=args.max_depth), end="")

--- a/tests/test_tree_lab.py
+++ b/tests/test_tree_lab.py
@@ -1,0 +1,81 @@
+import unittest
+from pathlib import Path
+import tempfile
+import argparse
+from io import StringIO
+from unittest.mock import patch
+
+from shared.tree_lab import TreeLabManager, run_tree_lab_logic
+
+
+class TestTreeLabManager(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir_obj = tempfile.TemporaryDirectory()
+        self.temp_dir = Path(self.temp_dir_obj.name)
+
+        # Create a sample structure
+        # temp_dir/
+        # ├── a_dir/
+        # │   └── file_in_a.txt
+        # ├── .git/
+        # │   └── config
+        # ├── b_file.txt
+        # └── c_dir/
+
+        (self.temp_dir / "a_dir").mkdir()
+        (self.temp_dir / "a_dir" / "file_in_a.txt").touch()
+
+        (self.temp_dir / ".git").mkdir()
+        (self.temp_dir / ".git" / "config").touch()
+
+        (self.temp_dir / "b_file.txt").touch()
+
+        (self.temp_dir / "c_dir").mkdir()
+
+    def tearDown(self):
+        self.temp_dir_obj.cleanup()
+
+    def test_default_excludes(self):
+        manager = TreeLabManager()
+        tree_str = manager.generate_tree(self.temp_dir)
+
+        # Expected structure (sorted: dirs first, then files):
+        # ├── a_dir
+        # │   └── file_in_a.txt
+        # ├── c_dir
+        # └── b_file.txt
+
+        self.assertIn("├── a_dir", tree_str)
+        self.assertIn("│   └── file_in_a.txt", tree_str)
+        self.assertIn("├── c_dir", tree_str)
+        self.assertIn("└── b_file.txt", tree_str)
+
+        # .git should be excluded
+        self.assertNotIn(".git", tree_str)
+
+    def test_custom_excludes(self):
+        manager = TreeLabManager(exclude=["c_dir"])
+        tree_str = manager.generate_tree(self.temp_dir)
+
+        self.assertNotIn("c_dir", tree_str)
+        self.assertIn(".git", tree_str)
+        self.assertIn("a_dir", tree_str)
+
+    def test_max_depth_0(self):
+        manager = TreeLabManager()
+        tree_str = manager.generate_tree(self.temp_dir, max_depth=0)
+
+        # Should only show the top level entries, not the children
+        self.assertIn("├── a_dir", tree_str)
+        self.assertNotIn("file_in_a.txt", tree_str)
+
+    def test_run_tree_lab_logic(self):
+        args = argparse.Namespace(dir=str(self.temp_dir), max_depth=-1, exclude=None)
+
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            run_tree_lab_logic(args)
+            output = mock_stdout.getvalue()
+
+            self.assertTrue(output.startswith(f"{self.temp_dir.resolve().name}/"))
+            self.assertIn("a_dir", output)
+            self.assertNotIn(".git", output)


### PR DESCRIPTION
This PR introduces a new `tree-lab` command that generates ASCII directory trees, similar to the Unix `tree` utility.

### Changes Made:
- Created `shared/tree_lab.py` with the core `TreeLabManager` logic to recursively iterate through directories, sort them gracefully (directories first, then files), and print tree branches using ASCII characters (`├──`, `└──`, `│`).
- Added CLI arguments for the target directory (`dir`), maximum depth (`--max-depth`), and exclusions (`--exclude`). By default, it ignores noisy directories like `.git`, `node_modules`, and Python caches.
- Registered the `tree-lab` sub-parser in `main.py` and hooked it into the main execution loop.
- Wrote unit tests in `tests/test_tree_lab.py` to ensure accurate formatting, accurate max-depth clipping, and proper exclusion list handling.

---
*PR created automatically by Jules for task [18405722475624235986](https://jules.google.com/task/18405722475624235986) started by @process-failed-successfully*