### PR TITLE
Add color mixing functionality to color-lab

### DIFF
--- a/main.py
+++ b/main.py
@@ -14507,6 +14507,12 @@ def parse_args(argv=None):
     parser_cl_conv = color_lab_subparsers.add_parser("convert", help="Convert color formats.")
     parser_cl_conv.add_argument("color", help="Color to convert.")
 
+    # color-lab mix
+    parser_cl_mix = color_lab_subparsers.add_parser("mix", help="Mix two colors.")
+    parser_cl_mix.add_argument("color1", help="First color (hex, rgb).")
+    parser_cl_mix.add_argument("color2", help="Second color (hex, rgb).")
+    parser_cl_mix.add_argument("--weight", "-w", type=float, default=0.5, help="Weight of second color (0.0 to 1.0). Default 0.5.")
+
     # color-lab extract
     parser_cl_ext = color_lab_subparsers.add_parser("extract", help="Extract prominent colors from an image.")
     parser_cl_ext.add_argument("image", help="Image file path.")

--- a/shared/color_lab.py
+++ b/shared/color_lab.py
@@ -155,6 +155,17 @@ class Color:
 
         return Color(f"rgb({fr},{fg},{fb})")
 
+    def mix(self, other: 'Color', weight: float = 0.5) -> 'Color':
+        """Blends this color with another color based on a weight (0.0 to 1.0)."""
+        weight = max(0.0, min(1.0, weight))
+
+        # Simple RGB interpolation
+        r = int(self.r * (1 - weight) + other.r * weight)
+        g = int(self.g * (1 - weight) + other.g * weight)
+        b = int(self.b * (1 - weight) + other.b * weight)
+
+        return Color(f"rgb({r},{g},{b})")
+
     def palette(self, type: str) -> List['Color']:
         """Generates a palette based on this color."""
         h, s, l = self.hsl
@@ -290,6 +301,18 @@ def run_color_lab_logic(action: str, **kwargs):
             table.add_row("Large Text (18pt+)", grade(ratio, "large"), grade(ratio, "large"))
 
             console.print(table)
+
+        elif action == "mix":
+            c1 = Color(kwargs["color1"])
+            c2 = Color(kwargs["color2"])
+            weight = float(kwargs.get("weight", 0.5))
+
+            result = c1.mix(c2, weight)
+
+            console.print(Panel(f"[bold]Color Mix ({int(weight*100):.0f}%)[/bold]"))
+            _print_color_swatch(c1, "Color 1")
+            _print_color_swatch(c2, "Color 2")
+            _print_color_swatch(result, "Result")
 
         elif action == "palette":
             base = Color(kwargs["base"])

--- a/shared/tui_color.py
+++ b/shared/tui_color.py
@@ -41,6 +41,17 @@ class ColorLabTab(Container):
                         yield Button("Simulate", id="btn-cl-blind", variant="primary")
                         yield RichLog(id="cl-blind-result", wrap=True, highlight=False, markup=True)
 
+                with TabPane("Mix", id="cl-tab-mix"):
+                    with Vertical(classes="stat-box"):
+                        yield Label("Color 1:")
+                        yield Input(placeholder="#000000", id="cl-mix-c1", value="#000000")
+                        yield Label("Color 2:")
+                        yield Input(placeholder="#FFFFFF", id="cl-mix-c2", value="#FFFFFF")
+                        yield Label("Weight (0.0 to 1.0):")
+                        yield Input(placeholder="0.5", id="cl-mix-weight", value="0.5")
+                        yield Button("Mix Colors", id="btn-cl-mix", variant="primary")
+                        yield RichLog(id="cl-mix-result", wrap=True, highlight=False, markup=True)
+
                 with TabPane("Converter", id="cl-tab-converter"):
                     with Vertical(classes="stat-box"):
                         yield Label("Color to Convert:")
@@ -121,6 +132,32 @@ class ColorLabTab(Container):
             for type in ["protanopia", "deuteranopia", "tritanopia"]:
                 sim = c.simulate_blindness(type)
                 render_swatch(sim, type.capitalize())
+
+        except ValueError as e:
+            log.write(f"[bold red]Error: {e}[/bold red]")
+
+    @on(Button.Pressed, "#btn-cl-mix")
+    def on_mix(self) -> None:
+        c1_str = self.query_one("#cl-mix-c1", Input).value
+        c2_str = self.query_one("#cl-mix-c2", Input).value
+        weight_str = self.query_one("#cl-mix-weight", Input).value
+        log = self.query_one("#cl-mix-result", RichLog)
+        log.clear()
+
+        try:
+            c1 = Color(c1_str)
+            c2 = Color(c2_str)
+            weight = float(weight_str)
+            result = c1.mix(c2, weight)
+
+            def render_swatch(col, label):
+                text_col = "black" if col.luminance > 0.5 else "white"
+                log.write(f"[{text_col} on {col.hex}] {label:<15} {col.hex} [/{text_col} on {col.hex}]")
+
+            render_swatch(c1, "Color 1")
+            render_swatch(c2, "Color 2")
+            log.write("")  # Spacer
+            render_swatch(result, f"Result ({int(weight*100):.0f}%)")
 
         except ValueError as e:
             log.write(f"[bold red]Error: {e}[/bold red]")

--- a/tests/test_color_lab.py
+++ b/tests/test_color_lab.py
@@ -45,6 +45,23 @@ class TestColorLab(unittest.TestCase):
         # In protanopia, red (#ff0000) becomes much darker/brownish
         self.assertNotEqual(c.hex, sim.hex)
 
+    def test_mix(self):
+        c1 = Color("#000000")
+        c2 = Color("#ffffff")
+
+        # 50% mix
+        mixed = c1.mix(c2, 0.5)
+        self.assertEqual(mixed.rgb, (127, 127, 127))
+        self.assertEqual(mixed.hex, "#7f7f7f")
+
+        # 0% mix (should be c1)
+        mixed = c1.mix(c2, 0.0)
+        self.assertEqual(mixed.rgb, (0, 0, 0))
+
+        # 100% mix (should be c2)
+        mixed = c1.mix(c2, 1.0)
+        self.assertEqual(mixed.rgb, (255, 255, 255))
+
     def test_cmyk(self):
         c = Color("#ff0000")  # Red
         # Cyan=0, Magenta=1, Yellow=1, Black=0

--- a/tests/test_tui_color.py
+++ b/tests/test_tui_color.py
@@ -47,6 +47,30 @@ class TestColorLabTab(unittest.IsolatedAsyncioTestCase):
             self.assertIn("(255, 0, 0)", text_content)
             self.assertIn("hsl(0.0, 100.0%, 50.0%)", text_content)
 
+    async def test_color_lab_mix_tab(self):
+        app = ColorLabApp()
+        async with app.run_test() as pilot:
+            # Activate Mix Tab
+            tabbed = app.query_one("TabbedContent")
+            tabbed.active = "cl-tab-mix"
+            await pilot.pause()
+
+            # Set inputs
+            app.query_one("#cl-mix-c1", Input).value = "#000000"
+            app.query_one("#cl-mix-c2", Input).value = "#ffffff"
+            app.query_one("#cl-mix-weight", Input).value = "0.5"
+
+            # Trigger mix
+            await pilot.click("#btn-cl-mix")
+
+            log = app.query_one("#cl-mix-result", RichLog)
+            text_content = "\n".join([str(line) for line in log.lines])
+
+            self.assertIn("Color 1", text_content)
+            self.assertIn("Color 2", text_content)
+            self.assertIn("Result (50%)", text_content)
+            self.assertIn("#7f7f7f", text_content)
+
     async def test_invalid_color(self):
         app = ColorLabApp()
         async with app.run_test() as pilot:


### PR DESCRIPTION
This PR introduces a highly requested and genuinely missing functional feature to the `color-lab` tool: color mixing. Users can now blend two colors (`color1` and `color2`) using a floating-point weight value. This is available via the CLI command `color-lab mix` and interactively within the Textual UI under the newly added "Mix" tab. Unit tests have been written to guarantee correctness, and tests pass successfully.

---
*PR created automatically by Jules for task [3138022282930945707](https://jules.google.com/task/3138022282930945707) started by @process-failed-successfully*