### PR TITLE
feat: add Atbash cipher lab with CLI and TUI support

### DIFF
--- a/main.py
+++ b/main.py
@@ -258,7 +258,7 @@ KNOWN_COMMANDS = [
     "hexdump-lab", "hexdump",
     "filetype-lab", "filetype", "magic-bytes",
     "bencode-lab", "bencode", "torrent",
-    "caesar-lab", "caesar", "vigenere-lab", "vigenere",
+    "caesar-lab", "caesar", "vigenere-lab", "vigenere", "atbash-lab", "atbash",
     "favicon-lab", "favicon",
     "msgpack-lab", "msgpack", "mpack",
     "bson-lab", "bson",
@@ -478,6 +478,30 @@ def run_vigenere_lab(args):
     from shared.vigenere_lab import run_vigenere_lab_logic
     import sys
     success = run_vigenere_lab_logic(args)
+    sys.exit(0 if success else 1)
+
+
+def run_atbash_lab(args):
+    """Runs the Atbash Lab."""
+    if getattr(args, "tui", False):
+        from shared.tui import AgentTUI
+        print("Launching Atbash Lab TUI...")
+        app = AgentTUI(project_dir=getattr(args, 'project_dir', None), start_tab="tab-atbash")
+        import asyncio
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop and loop.is_running():
+            asyncio.ensure_future(app.run_async())
+        else:
+            app.run()
+            sys.exit(0)
+        return
+
+    from shared.atbash_lab import run_atbash_lab_logic
+    import sys
+    success = run_atbash_lab_logic(args)
     sys.exit(0 if success else 1)
 
 
@@ -18277,6 +18301,14 @@ Examples:
     parser_vigenere.add_argument("--decode", "-d", action="store_true", help="Decode mode")
     parser_vigenere.add_argument("--tui", action="store_true", help="Launch Vigenère Lab TUI")
 
+    # atbash-lab
+    parser_atbash = subparsers.add_parser(
+        "atbash-lab", aliases=["atbash"],
+        help="Atbash Cipher Lab"
+    )
+    parser_atbash.add_argument("text", nargs="?", help="Text to process")
+    parser_atbash.add_argument("--tui", action="store_true", help="Launch Atbash Lab TUI")
+
     # caesar-lab
     parser_caesar = subparsers.add_parser(
         "caesar-lab", aliases=["caesar"],
@@ -25715,6 +25747,10 @@ async def main():
 
     if args.command in ["vigenere-lab", "vigenere"]:
         run_vigenere_lab(args)
+        return
+
+    if args.command in ["atbash-lab", "atbash"]:
+        run_atbash_lab(args)
         return
 
     if args.command in ["base64-lab", "base64", "b64"]:

--- a/shared/atbash_lab.py
+++ b/shared/atbash_lab.py
@@ -1,0 +1,38 @@
+import sys
+import argparse
+
+
+def atbash_cipher(text: str) -> str:
+    """Applies an Atbash cipher to the input text."""
+    if not text:
+        return text
+
+    result = []
+    for char in text:
+        if 'a' <= char <= 'z':
+            result.append(chr(ord('z') - (ord(char) - ord('a'))))
+        elif 'A' <= char <= 'Z':
+            result.append(chr(ord('Z') - (ord(char) - ord('A'))))
+        else:
+            result.append(char)
+
+    return "".join(result)
+
+
+def run_atbash_lab_logic(args: argparse.Namespace) -> bool:
+    """Runs the Atbash Lab logic."""
+    text = getattr(args, "text", None)
+
+    if not text:
+        if not sys.stdin.isatty():
+            text = sys.stdin.read()
+        else:
+            print("Error: No input text provided. Provide text as a positional argument or pipe data via stdin.", file=sys.stderr)
+            return False
+
+    if not text:
+        return False
+
+    result = atbash_cipher(text)
+    print(result, end="")
+    return True

--- a/shared/tui.py
+++ b/shared/tui.py
@@ -323,6 +323,7 @@ from shared.tui_roman import RomanLabTab
 from shared.tui_ocr import OcrLabTab
 from shared.tui_caesar import CaesarLabTab
 from shared.tui_vigenere import VigenereLabTab
+from shared.tui_atbash import AtbashLabTab
 from shared.tui_stego import StegoLabTab
 from shared.tui_exif import ExifLabTab
 from shared.tui_lorem import LoremLabTab
@@ -4692,6 +4693,8 @@ class AgentTUI(App):
                 yield CaesarLabTab()
             with TabPane("Vigenère Lab", id="tab-vigenere"):
                 yield VigenereLabTab()
+            with TabPane("Atbash Lab", id="tab-atbash"):
+                yield AtbashLabTab()
             with TabPane("Base64 Lab", id="tab-base64"):
                 yield Base64LabTab()
             with TabPane("Base64Url Lab", id="tab-base64url"):

--- a/shared/tui_atbash.py
+++ b/shared/tui_atbash.py
@@ -1,0 +1,31 @@
+from textual.app import ComposeResult
+from textual.widgets import Label, TextArea
+from textual.containers import Vertical, Horizontal
+from textual import on
+from shared.atbash_lab import atbash_cipher
+
+
+class AtbashLabTab(Vertical):
+    """Tab for experimenting with the Atbash cipher."""
+
+    def compose(self) -> ComposeResult:
+        yield Label("[bold]Atbash Lab[/bold]", classes="welcome-text")
+
+        with Horizontal(classes="stat-box"):
+            with Vertical():
+                yield Label("Input Text:")
+                yield TextArea(id="atbash-input", language=None)
+            with Vertical():
+                yield Label("Atbash Output:")
+                yield TextArea(id="atbash-output", read_only=True, language=None)
+
+    @on(TextArea.Changed, "#atbash-input")
+    def on_input_changed(self) -> None:
+        input_text = self.query_one("#atbash-input", TextArea).text
+        output_area = self.query_one("#atbash-output", TextArea)
+
+        if not input_text:
+            output_area.text = ""
+            return
+
+        output_area.text = atbash_cipher(input_text)

--- a/tests/test_atbash_lab.py
+++ b/tests/test_atbash_lab.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+from io import StringIO
+import argparse
+
+from shared.atbash_lab import atbash_cipher, run_atbash_lab_logic
+
+def test_atbash_cipher():
+    # Lowercase
+    assert atbash_cipher("abc") == "zyx"
+    assert atbash_cipher("xyz") == "cba"
+    # Uppercase
+    assert atbash_cipher("ABC") == "ZYX"
+    # Mixed and spaces
+    assert atbash_cipher("Hello World") == "Svool Dliow"
+    # Numbers and symbols
+    assert atbash_cipher("123!@#") == "123!@#"
+    assert atbash_cipher("Test 123!") == "Gvhg 123!"
+    # Non-ASCII characters (should remain untouched)
+    assert atbash_cipher("Café naïve") == "Xzué mzïev"
+
+def test_run_atbash_lab_logic_with_text():
+    args = argparse.Namespace(text="Hello", tui=False)
+    with patch("sys.stdout", new=StringIO()) as fake_stdout:
+        assert run_atbash_lab_logic(args) is True
+        assert fake_stdout.getvalue() == "Svool"
+
+def test_run_atbash_lab_logic_stdin():
+    args = argparse.Namespace(text=None, tui=False)
+    with patch("sys.stdin.isatty", return_value=False), \
+         patch("sys.stdin.read", return_value="apple"), \
+         patch("sys.stdout", new=StringIO()) as fake_stdout:
+        assert run_atbash_lab_logic(args) is True
+        assert fake_stdout.getvalue() == "zkkov"
+
+def test_run_atbash_lab_logic_no_input():
+    args = argparse.Namespace(text=None, tui=False)
+    with patch("sys.stdin.isatty", return_value=True), \
+         patch("sys.stderr", new=StringIO()) as fake_stderr:
+        assert run_atbash_lab_logic(args) is False
+        assert "Error: No input text provided" in fake_stderr.getvalue()


### PR DESCRIPTION
Adds the AtbashLab to the CLI tools and Textual UI:
- Creates `shared/atbash_lab.py` for core cipher logic and CLI processing
- Creates `shared/tui_atbash.py` for the interactive TUI tab
- Integrates the new feature into `main.py` routing under the `atbash-lab` (and `atbash` alias) command
- Wires up the TUI tab in `shared/tui.py`
- Adds full unit testing for the logic in `tests/test_atbash_lab.py`

---
*PR created automatically by Jules for task [2217210224504441668](https://jules.google.com/task/2217210224504441668) started by @process-failed-successfully*