### PR TITLE
feat(regex-lab): add extract subcommand

### DIFF
--- a/main.py
+++ b/main.py
@@ -13466,7 +13466,7 @@ def parse_args(argv=None):
     )
     parser_regex.add_argument(
         "action",
-        choices=["match", "explain", "generate", "game", "replace"],
+        choices=["match", "explain", "generate", "game", "replace", "extract"],
         help="Action to perform."
     )
     parser_regex.add_argument(
@@ -21615,6 +21615,24 @@ async def run_regex(args):
                     print(f"    Groups: {m['groups']}")
                 if m['group_dict']:
                     print(f"    Named Groups: {m['group_dict']}")
+        else:
+            print(f"❌ Regex Error: {result['error']}", file=sys.stderr)
+            sys.exit(1)
+
+    elif args.action == "extract":
+        if not args.pattern:
+            print("Error: --pattern is required for 'extract' action.", file=sys.stderr)
+            sys.exit(1)
+        if args.text is None:
+            print("Error: --text is required for 'extract' action.", file=sys.stderr)
+            sys.exit(1)
+
+        result = manager.extract_regex(args.pattern, args.text, flags)
+
+        if result["success"]:
+            print(f"✅ Extracted {result['count']} matches.")
+            for m in result["matches"]:
+                print(f"  {m!r}")
         else:
             print(f"❌ Regex Error: {result['error']}", file=sys.stderr)
             sys.exit(1)

--- a/shared/regex_lab.py
+++ b/shared/regex_lab.py
@@ -57,6 +57,33 @@ class RegexLabManager:
                 "error": str(e)
             }
 
+    def extract_regex(self, pattern: str, text: str, flags: int = 0) -> Dict[str, Any]:
+        """
+        Extracts all matches of a regex pattern from text.
+
+        Args:
+            pattern: The regex pattern.
+            text: The text to search.
+            flags: Regex flags (e.g. re.IGNORECASE).
+
+        Returns:
+            Dict containing the list of extracted matching strings.
+        """
+        try:
+            matches = list(re.finditer(pattern, text, flags))
+            results: List[str] = [match.group(0) for match in matches]
+
+            return {
+                "success": True,
+                "count": len(results),
+                "matches": results
+            }
+        except re.error as e:
+            return {
+                "success": False,
+                "error": str(e)
+            }
+
     def replace_regex(self, pattern: str, replacement: str, text: str, flags: int = 0) -> Dict[str, Any]:
         """
         Replaces text matching a regex pattern.

--- a/tests/test_regex_lab_extract.py
+++ b/tests/test_regex_lab_extract.py
@@ -1,0 +1,33 @@
+import unittest
+from shared.regex_lab import RegexLabManager
+import re
+
+class TestRegexLabExtract(unittest.TestCase):
+    def setUp(self):
+        self.manager = RegexLabManager()
+
+    def test_extract_regex_basic(self):
+        result = self.manager.extract_regex(r"\d+", "123 abc 456 def")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["count"], 2)
+        self.assertEqual(result["matches"], ["123", "456"])
+
+    def test_extract_regex_no_match(self):
+        result = self.manager.extract_regex(r"\d+", "abc def")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["count"], 0)
+        self.assertEqual(result["matches"], [])
+
+    def test_extract_regex_with_flags(self):
+        result = self.manager.extract_regex(r"abc", "ABC def AbC", flags=re.IGNORECASE)
+        self.assertTrue(result["success"])
+        self.assertEqual(result["count"], 2)
+        self.assertEqual(result["matches"], ["ABC", "AbC"])
+
+    def test_extract_regex_invalid_pattern(self):
+        result = self.manager.extract_regex(r"[unclosed", "text")
+        self.assertFalse(result["success"])
+        self.assertIn("error", result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented a new functional CLI usability feature: `extract` action for the `regex` subcommand. This allows users to easily get a list of all matched strings for a given regular expression from an input text. Tests were added to ensure the extraction behaves correctly under various conditions. All core application routing tests passed successfully.

---
*PR created automatically by Jules for task [15953055525750210309](https://jules.google.com/task/15953055525750210309) started by @process-failed-successfully*