### PR TITLE
feat: Add Ed25519 signing and verification to Crypto Lab

### DIFF
--- a/shared/crypto_lab.py
+++ b/shared/crypto_lab.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 from typing import Union
 from cryptography.fernet import Fernet
-from cryptography.hazmat.primitives.asymmetric import rsa, padding
+from cryptography.hazmat.primitives.asymmetric import rsa, padding, ed25519
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.exceptions import InvalidSignature
 
@@ -215,6 +215,47 @@ class CryptoLabManager:
                 ),
                 hashes.SHA256()
             )
+            return True
+        except InvalidSignature:
+            return False
+
+    def generate_ed25519_keypair(self) -> tuple[bytes, bytes]:
+        """Generates an Ed25519 private and public key pair."""
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        private_bytes = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption()
+        )
+        public_key = private_key.public_key()
+        public_bytes = public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo
+        )
+        return private_bytes, public_bytes
+
+    def ed25519_sign(self, input_data: Union[str, bytes], private_key_bytes: bytes) -> bytes:
+        """Signs data using an Ed25519 private key."""
+        private_key = serialization.load_pem_private_key(
+            private_key_bytes,
+            password=None,
+        )
+        if isinstance(input_data, str):
+            data_bytes = input_data.encode("utf-8")
+        else:
+            data_bytes = input_data
+        signature = private_key.sign(data_bytes)
+        return signature
+
+    def ed25519_verify(self, input_data: Union[str, bytes], signature: bytes, public_key_bytes: bytes) -> bool:
+        """Verifies a signature using an Ed25519 public key."""
+        public_key = serialization.load_pem_public_key(public_key_bytes)
+        if isinstance(input_data, str):
+            data_bytes = input_data.encode("utf-8")
+        else:
+            data_bytes = input_data
+        try:
+            public_key.verify(signature, data_bytes)
             return True
         except InvalidSignature:
             return False
@@ -505,6 +546,64 @@ def run_crypto_lab_logic(args) -> bool:
                 return False
 
             if manager.rsa_verify(data, signature, key):
+                print("Signature Verified: OK")
+                return True
+            else:
+                print("Signature Verified: FAILED", file=sys.stderr)
+                return False
+
+        elif args.action == "ed25519-keygen":
+            priv, pub = manager.generate_ed25519_keypair()
+            if args.output:
+                Path(f"{args.output}").write_bytes(priv)
+                Path(f"{args.output}.pub").write_bytes(pub)
+                print(f"Keypair saved to {args.output} and {args.output}.pub")
+            else:
+                print("--- Private Key ---")
+                print(priv.decode('utf-8'))
+                print("--- Public Key ---")
+                print(pub.decode('utf-8'))
+            return True
+
+        elif args.action == "ed25519-sign":
+            key = None
+            if args.key:
+                key = args.key.encode("utf-8")
+            elif args.key_file:
+                key = Path(args.key_file).read_bytes()
+            if not key:
+                print("Error: Private key required.", file=sys.stderr)
+                return False
+
+            data = args.text if args.text else Path(args.file).read_bytes() if args.file else sys.stdin.buffer.read()
+            signature = manager.ed25519_sign(data, key)
+            if args.output:
+                Path(args.output).write_bytes(signature)
+            else:
+                print(base64.b64encode(signature).decode('utf-8'))
+            return True
+
+        elif args.action == "ed25519-verify":
+            key = None
+            if args.key:
+                key = args.key.encode("utf-8")
+            elif args.key_file:
+                key = Path(args.key_file).read_bytes()
+            if not key:
+                print("Error: Public key required.", file=sys.stderr)
+                return False
+
+            data = args.text if args.text else Path(args.file).read_bytes() if args.file else sys.stdin.buffer.read()
+
+            if args.signature:
+                signature = base64.b64decode(args.signature)
+            elif args.signature_file:
+                signature = Path(args.signature_file).read_bytes()
+            else:
+                print("Error: Signature required.", file=sys.stderr)
+                return False
+
+            if manager.ed25519_verify(data, signature, key):
                 print("Signature Verified: OK")
                 return True
             else:

--- a/shared/tui_crypto.py
+++ b/shared/tui_crypto.py
@@ -128,6 +128,30 @@ class CryptoLabTab(Container):
                         yield Label("[bold]Output (Text or Base64)[/bold]")
                         yield TextArea(id="crypto-rsa-output", read_only=True)
 
+                # Ed25519
+                with TabPane("Ed25519"):
+                    with Horizontal(classes="stat-box"):
+                        with Vertical():
+                            yield Label("Private Key:")
+                            yield TextArea(id="crypto-ed-priv")
+                        with Vertical():
+                            yield Label("Public Key:")
+                            yield TextArea(id="crypto-ed-pub")
+                    with Vertical(classes="stat-box"):
+                        yield Label("Input Text:")
+                        yield TextArea(id="crypto-ed-input")
+                    with Horizontal():
+                        yield Button("Generate Keypair", id="btn-crypto-ed-gen", variant="success")
+                        yield Button("Sign", id="btn-crypto-ed-sign", variant="primary")
+                        yield Button("Verify", id="btn-crypto-ed-verify", variant="primary")
+                    with Horizontal(classes="stat-box"):
+                        with Vertical():
+                            yield Label("Signature (Base64) (for Verify):")
+                            yield TextArea(id="crypto-ed-signature")
+                    with Vertical(classes="stat-box"):
+                        yield Label("[bold]Output (Text or Base64)[/bold]")
+                        yield TextArea(id="crypto-ed-output", read_only=True)
+
                 # Random
                 with TabPane("Random"):
                     with Horizontal(classes="stat-box"):
@@ -169,6 +193,12 @@ class CryptoLabTab(Container):
             self.do_rsa_sign()
         elif event.button.id == "btn-crypto-rsa-verify":
             self.do_rsa_verify()
+        elif event.button.id == "btn-crypto-ed-gen":
+            self.do_ed_gen()
+        elif event.button.id == "btn-crypto-ed-sign":
+            self.do_ed_sign()
+        elif event.button.id == "btn-crypto-ed-verify":
+            self.do_ed_verify()
 
     def do_hash(self) -> None:
         text = self.query_one("#crypto-hash-input", TextArea).text
@@ -183,6 +213,51 @@ class CryptoLabTab(Container):
             res = self.manager.hash_data(text, str(algo))
             out.text = res
             self.notify("Hash calculated.")
+        except Exception as e:
+            self.notify(f"Error: {e}", severity="error")
+
+    def do_ed_gen(self) -> None:
+        try:
+            priv, pub = self.manager.generate_ed25519_keypair()
+            self.query_one("#crypto-ed-priv", TextArea).text = priv.decode("utf-8")
+            self.query_one("#crypto-ed-pub", TextArea).text = pub.decode("utf-8")
+            self.notify("Ed25519 Keypair generated.")
+        except Exception as e:
+            self.notify(f"Error: {e}", severity="error")
+
+    def do_ed_sign(self) -> None:
+        priv = self.query_one("#crypto-ed-priv", TextArea).text
+        text = self.query_one("#crypto-ed-input", TextArea).text
+        out = self.query_one("#crypto-ed-output", TextArea)
+
+        if not priv or not text:
+            self.notify("Private key and input required.", severity="error")
+            return
+
+        try:
+            import base64
+            res = self.manager.ed25519_sign(text, priv.encode("utf-8"))
+            out.text = base64.b64encode(res).decode("utf-8")
+            self.notify("Signed.")
+        except Exception as e:
+            self.notify(f"Error: {e}", severity="error")
+
+    def do_ed_verify(self) -> None:
+        pub = self.query_one("#crypto-ed-pub", TextArea).text
+        text = self.query_one("#crypto-ed-input", TextArea).text
+        sig_text = self.query_one("#crypto-ed-signature", TextArea).text.strip()
+        if not pub or not text or not sig_text:
+            self.notify("Public key, input text, and signature required.", severity="error")
+            return
+
+        try:
+            import base64
+            sig = base64.b64decode(sig_text)
+            is_valid = self.manager.ed25519_verify(text, sig, pub.encode("utf-8"))
+            if is_valid:
+                self.notify("Signature is VALID.", severity="information")
+            else:
+                self.notify("Signature is INVALID.", severity="error")
         except Exception as e:
             self.notify(f"Error: {e}", severity="error")
 

--- a/tests/test_crypto_lab.py
+++ b/tests/test_crypto_lab.py
@@ -206,3 +206,30 @@ def test_cli_rsa_keygen(capsys):
     captured = capsys.readouterr()
     assert "BEGIN PRIVATE KEY" in captured.out
     assert "BEGIN PUBLIC KEY" in captured.out
+
+def test_ed25519_keygen(crypto_manager):
+    priv, pub = crypto_manager.generate_ed25519_keypair()
+    assert b"BEGIN PRIVATE KEY" in priv
+    assert b"BEGIN PUBLIC KEY" in pub
+
+def test_ed25519_sign_verify(crypto_manager):
+    priv, pub = crypto_manager.generate_ed25519_keypair()
+    test_str = "secret_data"
+    signature = crypto_manager.ed25519_sign(test_str, priv)
+
+    is_valid = crypto_manager.ed25519_verify(test_str, signature, pub)
+    assert is_valid
+
+    # Test invalid signature
+    is_invalid = crypto_manager.ed25519_verify(test_str, b"bad_signature_padding12345", pub)
+    assert not is_invalid
+
+def test_cli_ed25519_keygen(capsys):
+    args = MagicMock()
+    args.action = "ed25519-keygen"
+    args.output = None
+
+    run_crypto_lab_logic(args)
+    captured = capsys.readouterr()
+    assert "BEGIN PRIVATE KEY" in captured.out
+    assert "BEGIN PUBLIC KEY" in captured.out


### PR DESCRIPTION
This PR adds support for generating Ed25519 keypairs, creating signatures, and verifying them. The new functionality is available via the `crypto-lab` CLI using new subcommands (`ed25519-keygen`, `ed25519-sign`, `ed25519-verify`) as well as interactively within a new `Ed25519` TabPane in the TUI (`tui_crypto.py`). Tests were added to ensure the correct behavior of the backend logic.

---
*PR created automatically by Jules for task [4792950478537924967](https://jules.google.com/task/4792950478537924967) started by @process-failed-successfully*