### PR TITLE
Improve DidYouMeanArgumentParser output

### DIFF
--- a/main.py
+++ b/main.py
@@ -10014,7 +10014,9 @@ class DidYouMeanArgumentParser(argparse.ArgumentParser):
 
                 if matches:
                     suggestions = ", ".join([f"'{m}'" for m in matches])
-                    message = f"{message}\n\nDid you mean: {suggestions}?"
+                    message = f"invalid choice: '{invalid_choice}'\n\nDid you mean: {suggestions}?"
+                else:
+                    message = f"invalid choice: '{invalid_choice}'"
 
         self.print_usage(sys.stderr)
         args = {'prog': self.prog, 'message': message}

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -21,6 +21,9 @@ def test_did_you_mean_suggestion():
     # Standard argparse output should be there
     assert "invalid choice: 'jsno'" in result.stderr
 
+    # Assert that the choose from list is NOT there to keep output clean
+    assert "(choose from" not in result.stderr
+
     # Our new DidYouMean suggestion should be there
     assert "Did you mean:" in result.stderr
     assert "'json'" in result.stderr
@@ -41,6 +44,9 @@ def test_did_you_mean_no_suggestion():
 
     assert result.returncode == 2
     assert "invalid choice: 'xyz123thisisnotacommandatall'" in result.stderr
+
+    # Assert that the choose from list is NOT there to keep output clean
+    assert "(choose from" not in result.stderr
 
     # There shouldn't be a suggestion for something completely random
     assert "Did you mean:" not in result.stderr


### PR DESCRIPTION
The CLI previously dumped out over 500 options into `stderr` anytime an invalid choice was typed, making the actual error message practically unreadable. I've improved the `DidYouMeanArgumentParser` to strip out this list and present a cleaner error message.

---
*PR created automatically by Jules for task [4911862311930315684](https://jules.google.com/task/4911862311930315684) started by @process-failed-successfully*